### PR TITLE
Fix referral agent import and extend docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,20 @@ The `tools` package contains submodules for CRM integrations, email and doc gene
 ### 🏡 Real Estate Expansion
 
 A new `Real Estate Team` demonstrates how the framework can be adapted for other industries. It bundles agents for finding leads, pulling MLS data, creating listings and posting them to major portals. See `src/teams/real_estate_team.json` for the configuration and the accompanying tools under `src/tools/real_estate_tools`.
+
+### 🚧 Building Modular AutoGen Teams
+
+The JSON files under `src/teams/` showcase how to wire multiple agents together
+using [AutoGen](https://github.com/microsoft/autogen). Each file describes a
+`RoundRobinGroupChat` with a list of **participants** and optional tools. To
+create a new industry workflow:
+
+1. Copy one of the existing team JSONs and update the `participants` section
+   with your agents.
+2. Add `FunctionTool` entries for any custom business logic your agents need.
+3. Adjust the termination conditions (for example `MaxMessageTermination`) to
+   control when the team conversation stops.
+
+By editing these declarative configs you can quickly deploy specialised agent
+teams for finance, healthcare, manufacturing or any other domain without
+changing the core orchestrator code.

--- a/src/agents/referral_agent.py
+++ b/src/agents/referral_agent.py
@@ -1,7 +1,7 @@
 # src/agents/referral_agent.py
 
 from .base_agent import BaseAgent
-from ..tools/email_tool import EmailTool
+from ..tools.email_tool import EmailTool
 from ..utils.logger import get_logger
 
 logger = get_logger(__name__)


### PR DESCRIPTION
## Summary
- fix invalid import path in `ReferralAgent`
- document how to create new AutoGen teams

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
