### PR TITLE
Add logistics operations teams and tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ The `tools` package contains submodules for CRM integrations, email and doc gene
 
 A new `Real Estate Team` demonstrates how the framework can be adapted for other industries. It bundles agents for finding leads, pulling MLS data, creating listings and posting them to major portals. See `src/teams/real_estate_team.json` for the configuration and the accompanying tools under `src/tools/real_estate_tools`.
 
+### 🚚 Operations & Fulfillment Teams
+
+Several additional JSON configs showcase logistics workflows. New teams cover warehouse operations, inventory management, order fulfillment, driver tracking and e-commerce. These rely on the tools in `src/tools/operations_tools` and `src/tools/ecommerce_tool.py` for TMS, inventory and shopping cart integrations along with Microsoft Teams notifications.
+
 ### 🚧 Building Modular AutoGen Teams
 
 The JSON files under `src/teams/` showcase how to wire multiple agents together

--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -33,6 +33,13 @@ __all__ = [
     'MLSAgent',
     'ListingAgent',
     'ListingPosterAgent',
+    'InboundAgent',
+    'OutboundAgent',
+    'InventoryManagementAgent',
+    'TMSAgent',
+    'FulfillmentAgent',
+    'OnRoadAgent',
+    'EcommerceAgent',
 ]
 
 _module_map: Dict[str, str] = {
@@ -64,6 +71,13 @@ _module_map: Dict[str, str] = {
     'MLSAgent': 'mls_agent',
     'ListingAgent': 'listing_agent',
     'ListingPosterAgent': 'listing_poster_agent',
+    'InboundAgent': 'inbound_agent',
+    'OutboundAgent': 'outbound_agent',
+    'InventoryManagementAgent': 'inventory_management_agent',
+    'TMSAgent': 'tms_agent',
+    'FulfillmentAgent': 'fulfillment_agent',
+    'OnRoadAgent': 'on_road_agent',
+    'EcommerceAgent': 'ecommerce_agent',
 }
 
 

--- a/src/agents/ecommerce_agent.py
+++ b/src/agents/ecommerce_agent.py
@@ -1,0 +1,16 @@
+from .base_agent import BaseAgent
+import importlib
+from ..utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+class EcommerceAgent(BaseAgent):
+    def __init__(self):
+        EcommerceTool = importlib.import_module("src.tools.ecommerce_tool").EcommerceTool
+        self.ecommerce = EcommerceTool()
+
+    def run(self, payload: dict) -> dict:
+        """Create a new ecommerce order."""
+        order = self.ecommerce.create_order(payload["order"])
+        logger.info(f"Created ecommerce order {order.get('id')}")
+        return {"order_id": order.get("id"), "status": "created"}

--- a/src/agents/fulfillment_agent.py
+++ b/src/agents/fulfillment_agent.py
@@ -1,0 +1,20 @@
+from .base_agent import BaseAgent
+import importlib
+from ..utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+class FulfillmentAgent(BaseAgent):
+    def __init__(self):
+        EcommerceTool = importlib.import_module("src.tools.ecommerce_tool").EcommerceTool
+        InventoryTool = importlib.import_module("src.tools.operations_tools.inventory_tool").InventoryTool
+        self.ecommerce = EcommerceTool()
+        self.inventory = InventoryTool()
+
+    def run(self, payload: dict) -> dict:
+        """Fulfill an e-commerce order."""
+        order = self.ecommerce.get_order(payload["order_id"])
+        for item in order.get("items", []):
+            self.inventory.update_inventory(item["sku"], -item["qty"])
+        logger.info(f"Fulfilled order {payload['order_id']}")
+        return {"order_id": payload["order_id"], "status": "fulfilled"}

--- a/src/agents/inbound_agent.py
+++ b/src/agents/inbound_agent.py
@@ -1,0 +1,20 @@
+from .base_agent import BaseAgent
+import importlib
+from ..utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+class InboundAgent(BaseAgent):
+    def __init__(self):
+        TMSTool = importlib.import_module("src.tools.operations_tools.tms_tool").TMSTool
+        InventoryTool = importlib.import_module("src.tools.operations_tools.inventory_tool").InventoryTool
+        self.tms = TMSTool()
+        self.inventory = InventoryTool()
+
+    def run(self, payload: dict) -> dict:
+        """Process an inbound trailer and update inventory."""
+        for item in payload.get("items", []):
+            self.inventory.update_inventory(item["sku"], item["qty"])
+        shipment = self.tms.create_shipment({"trailer_id": payload["trailer_id"], "direction": "inbound"})
+        logger.info(f"Processed inbound trailer {payload['trailer_id']}")
+        return {"shipment_id": shipment.get("id"), "status": "inbound_processed"}

--- a/src/agents/inventory_management_agent.py
+++ b/src/agents/inventory_management_agent.py
@@ -1,0 +1,18 @@
+from .base_agent import BaseAgent
+import importlib
+from ..utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+class InventoryManagementAgent(BaseAgent):
+    def __init__(self):
+        InventoryTool = importlib.import_module("src.tools.operations_tools.inventory_tool").InventoryTool
+        self.inventory = InventoryTool()
+
+    def run(self, payload: dict) -> dict:
+        """Update inventory counts."""
+        item_id = payload["item_id"]
+        qty = int(payload.get("qty", 0))
+        result = self.inventory.update_inventory(item_id, qty)
+        logger.info(f"Inventory updated for {item_id}")
+        return {"item_id": item_id, "status": "updated", "result": result}

--- a/src/agents/on_road_agent.py
+++ b/src/agents/on_road_agent.py
@@ -1,0 +1,18 @@
+from .base_agent import BaseAgent
+import importlib
+from ..utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+class OnRoadAgent(BaseAgent):
+    def __init__(self):
+        TMSTool = importlib.import_module("src.tools.operations_tools.tms_tool").TMSTool
+        self.tms = TMSTool()
+
+    def run(self, payload: dict) -> dict:
+        """Update live location for a shipment."""
+        shipment_id = payload["shipment_id"]
+        location = payload["location"]
+        result = self.tms.update_status(shipment_id, f"enroute:{location}")
+        logger.info(f"Updated location for {shipment_id} -> {location}")
+        return {"shipment_id": shipment_id, "status": "location_updated", "result": result}

--- a/src/agents/outbound_agent.py
+++ b/src/agents/outbound_agent.py
@@ -1,0 +1,20 @@
+from .base_agent import BaseAgent
+import importlib
+from ..utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+class OutboundAgent(BaseAgent):
+    def __init__(self):
+        TMSTool = importlib.import_module("src.tools.operations_tools.tms_tool").TMSTool
+        InventoryTool = importlib.import_module("src.tools.operations_tools.inventory_tool").InventoryTool
+        self.tms = TMSTool()
+        self.inventory = InventoryTool()
+
+    def run(self, payload: dict) -> dict:
+        """Process an outbound trailer and decrement inventory."""
+        for item in payload.get("items", []):
+            self.inventory.update_inventory(item["sku"], -item["qty"])
+        shipment = self.tms.create_shipment({"trailer_id": payload["trailer_id"], "direction": "outbound"})
+        logger.info(f"Processed outbound trailer {payload['trailer_id']}")
+        return {"shipment_id": shipment.get("id"), "status": "outbound_processed"}

--- a/src/agents/tms_agent.py
+++ b/src/agents/tms_agent.py
@@ -1,0 +1,18 @@
+from .base_agent import BaseAgent
+import importlib
+from ..utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+class TMSAgent(BaseAgent):
+    def __init__(self):
+        TMSTool = importlib.import_module("src.tools.operations_tools.tms_tool").TMSTool
+        self.tms = TMSTool()
+
+    def run(self, payload: dict) -> dict:
+        """Update shipment status in the TMS."""
+        shipment_id = payload["shipment_id"]
+        status = payload["status"]
+        result = self.tms.update_status(shipment_id, status)
+        logger.info(f"Shipment {shipment_id} updated to {status}")
+        return {"shipment_id": shipment_id, "status": "updated", "result": result}

--- a/src/constants.py
+++ b/src/constants.py
@@ -95,3 +95,11 @@ PUSHOVER_API_TOKEN        = os.getenv("PUSHOVER_API_TOKEN")
 DISCORD_WEBHOOK_URL       = os.getenv("DISCORD_WEBHOOK_URL")
 AWS_SES_REGION            = os.getenv("AWS_SES_REGION", "us-east-1")
 CONFIG_PATH               = os.getenv("CONFIG_PATH", "config/playbook.yaml")
+
+# Logistics & e-commerce APIs
+TMS_API_URL           = os.getenv("TMS_API_URL")
+TMS_API_KEY           = os.getenv("TMS_API_KEY")
+INVENTORY_API_URL     = os.getenv("INVENTORY_API_URL")
+INVENTORY_API_KEY     = os.getenv("INVENTORY_API_KEY")
+ECOMMERCE_API_URL     = os.getenv("ECOMMERCE_API_URL")
+ECOMMERCE_API_KEY     = os.getenv("ECOMMERCE_API_KEY")

--- a/src/teams/ecommerce_team.json
+++ b/src/teams/ecommerce_team.json
@@ -1,0 +1,55 @@
+{
+  "provider": "autogen_agentchat.teams.RoundRobinGroupChat",
+  "component_type": "team",
+  "version": 1,
+  "component_version": 1,
+  "description": "E-commerce order management team.",
+  "label": "E-commerce Team",
+  "config": {
+    "participants": [
+      {
+        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "component_type": "agent",
+        "version": 1,
+        "component_version": 1,
+        "description": "Create ecommerce orders.",
+        "label": "Ecommerce Agent",
+        "config": {"name": "ecommerce_agent"}
+      },
+      {
+        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "component_type": "agent",
+        "version": 1,
+        "component_version": 1,
+        "description": "Fulfill ecommerce orders and update inventory.",
+        "label": "Fulfillment Agent",
+        "config": {"name": "fulfillment_agent"}
+      },
+      {
+        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "component_type": "agent",
+        "version": 1,
+        "component_version": 1,
+        "description": "Send notifications to Microsoft Teams.",
+        "label": "Notification Agent",
+        "config": {"name": "notification_agent"}
+      }
+    ],
+    "termination_condition": {
+      "provider": "autogen_agentchat.base.OrTerminationCondition",
+      "component_type": "termination",
+      "label": "TerminateOnText",
+      "config": {
+        "conditions": [
+          {
+            "provider": "autogen_agentchat.conditions.TextMentionTermination",
+            "component_type": "termination",
+            "label": "TermOnText",
+            "config": {"text": "TERMINATE"}
+          }
+        ]
+      }
+    },
+    "emit_team_events": false
+  }
+}

--- a/src/teams/fulfillment_pipeline_team.json
+++ b/src/teams/fulfillment_pipeline_team.json
@@ -1,0 +1,64 @@
+{
+  "provider": "autogen_agentchat.teams.RoundRobinGroupChat",
+  "component_type": "team",
+  "version": 1,
+  "component_version": 1,
+  "description": "Sales order fulfillment pipeline.",
+  "label": "Fulfillment Pipeline Team",
+  "config": {
+    "participants": [
+      {
+        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "component_type": "agent",
+        "version": 1,
+        "component_version": 1,
+        "description": "Fulfill ecommerce orders and reserve inventory.",
+        "label": "Fulfillment Agent",
+        "config": {"name": "fulfillment_agent"}
+      },
+      {
+        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "component_type": "agent",
+        "version": 1,
+        "component_version": 1,
+        "description": "Manage warehouse inventory counts.",
+        "label": "Inventory Management Agent",
+        "config": {"name": "inventory_management_agent"}
+      },
+      {
+        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "component_type": "agent",
+        "version": 1,
+        "component_version": 1,
+        "description": "Integrate with the TMS system for shipping updates.",
+        "label": "TMS Agent",
+        "config": {"name": "tms_agent"}
+      },
+      {
+        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "component_type": "agent",
+        "version": 1,
+        "component_version": 1,
+        "description": "Send notifications to Microsoft Teams.",
+        "label": "Notification Agent",
+        "config": {"name": "notification_agent"}
+      }
+    ],
+    "termination_condition": {
+      "provider": "autogen_agentchat.base.OrTerminationCondition",
+      "component_type": "termination",
+      "label": "TerminateOnText",
+      "config": {
+        "conditions": [
+          {
+            "provider": "autogen_agentchat.conditions.TextMentionTermination",
+            "component_type": "termination",
+            "label": "TermOnText",
+            "config": {"text": "TERMINATE"}
+          }
+        ]
+      }
+    },
+    "emit_team_events": false
+  }
+}

--- a/src/teams/inventory_management_team.json
+++ b/src/teams/inventory_management_team.json
@@ -1,0 +1,46 @@
+{
+  "provider": "autogen_agentchat.teams.RoundRobinGroupChat",
+  "component_type": "team",
+  "version": 1,
+  "component_version": 1,
+  "description": "Dedicated inventory management team.",
+  "label": "Inventory Management Team",
+  "config": {
+    "participants": [
+      {
+        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "component_type": "agent",
+        "version": 1,
+        "component_version": 1,
+        "description": "Manage warehouse inventory counts.",
+        "label": "Inventory Management Agent",
+        "config": {"name": "inventory_management_agent"}
+      },
+      {
+        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "component_type": "agent",
+        "version": 1,
+        "component_version": 1,
+        "description": "Send notifications to Microsoft Teams.",
+        "label": "Notification Agent",
+        "config": {"name": "notification_agent"}
+      }
+    ],
+    "termination_condition": {
+      "provider": "autogen_agentchat.base.OrTerminationCondition",
+      "component_type": "termination",
+      "label": "TerminateOnText",
+      "config": {
+        "conditions": [
+          {
+            "provider": "autogen_agentchat.conditions.TextMentionTermination",
+            "component_type": "termination",
+            "label": "TermOnText",
+            "config": {"text": "TERMINATE"}
+          }
+        ]
+      }
+    },
+    "emit_team_events": false
+  }
+}

--- a/src/teams/on_the_road_team.json
+++ b/src/teams/on_the_road_team.json
@@ -1,0 +1,46 @@
+{
+  "provider": "autogen_agentchat.teams.RoundRobinGroupChat",
+  "component_type": "team",
+  "version": 1,
+  "component_version": 1,
+  "description": "Drivers and shipment tracking team.",
+  "label": "On The Road Team",
+  "config": {
+    "participants": [
+      {
+        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "component_type": "agent",
+        "version": 1,
+        "component_version": 1,
+        "description": "Update live shipment locations.",
+        "label": "On Road Agent",
+        "config": {"name": "on_road_agent"}
+      },
+      {
+        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "component_type": "agent",
+        "version": 1,
+        "component_version": 1,
+        "description": "Send notifications to Microsoft Teams.",
+        "label": "Notification Agent",
+        "config": {"name": "notification_agent"}
+      }
+    ],
+    "termination_condition": {
+      "provider": "autogen_agentchat.base.OrTerminationCondition",
+      "component_type": "termination",
+      "label": "TerminateOnText",
+      "config": {
+        "conditions": [
+          {
+            "provider": "autogen_agentchat.conditions.TextMentionTermination",
+            "component_type": "termination",
+            "label": "TermOnText",
+            "config": {"text": "TERMINATE"}
+          }
+        ]
+      }
+    },
+    "emit_team_events": false
+  }
+}

--- a/src/teams/operations_team.json
+++ b/src/teams/operations_team.json
@@ -1,0 +1,73 @@
+{
+  "provider": "autogen_agentchat.teams.RoundRobinGroupChat",
+  "component_type": "team",
+  "version": 1,
+  "component_version": 1,
+  "description": "Autonomous agents for logistics operations.",
+  "label": "Operations Team",
+  "config": {
+    "participants": [
+      {
+        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "component_type": "agent",
+        "version": 1,
+        "component_version": 1,
+        "description": "Handle inbound trailers and inventory updates.",
+        "label": "Inbound Agent",
+        "config": {"name": "inbound_agent"}
+      },
+      {
+        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "component_type": "agent",
+        "version": 1,
+        "component_version": 1,
+        "description": "Handle outbound trailers and shipping.",
+        "label": "Outbound Agent",
+        "config": {"name": "outbound_agent"}
+      },
+      {
+        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "component_type": "agent",
+        "version": 1,
+        "component_version": 1,
+        "description": "Manage warehouse inventory counts.",
+        "label": "Inventory Management Agent",
+        "config": {"name": "inventory_management_agent"}
+      },
+      {
+        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "component_type": "agent",
+        "version": 1,
+        "component_version": 1,
+        "description": "Integrate with the TMS system.",
+        "label": "TMS Agent",
+        "config": {"name": "tms_agent"}
+      },
+      {
+        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "component_type": "agent",
+        "version": 1,
+        "component_version": 1,
+        "description": "Send notifications to Microsoft Teams.",
+        "label": "Notification Agent",
+        "config": {"name": "notification_agent"}
+      }
+    ],
+    "termination_condition": {
+      "provider": "autogen_agentchat.base.OrTerminationCondition",
+      "component_type": "termination",
+      "label": "TerminateOnText",
+      "config": {
+        "conditions": [
+          {
+            "provider": "autogen_agentchat.conditions.TextMentionTermination",
+            "component_type": "termination",
+            "label": "TermOnText",
+            "config": {"text": "TERMINATE"}
+          }
+        ]
+      }
+    },
+    "emit_team_events": false
+  }
+}

--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -15,4 +15,6 @@ __all__ = [
     "scoring_service_tools",
     "segmentation_tools",
     "visitor_tracking_tools",
+    "operations_tools",
+    "ecommerce_tool",
 ]

--- a/src/tools/ecommerce_tool.py
+++ b/src/tools/ecommerce_tool.py
@@ -1,0 +1,35 @@
+"""Generic e-commerce platform client used for order operations."""
+
+try:
+    import requests
+except ImportError:  # pragma: no cover
+    requests = None
+
+from ..constants import ECOMMERCE_API_URL, ECOMMERCE_API_KEY
+from ..utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+class EcommerceTool:
+    def create_order(self, order: dict) -> dict:
+        logger.info("Creating ecommerce order")
+        if not requests:
+            raise RuntimeError("requests package is not installed")
+        resp = requests.post(
+            f"{ECOMMERCE_API_URL}/orders",
+            json=order,
+            headers={"Authorization": f"Bearer {ECOMMERCE_API_KEY}"},
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_order(self, order_id: str) -> dict:
+        logger.info(f"Fetching order {order_id}")
+        if not requests:
+            raise RuntimeError("requests package is not installed")
+        resp = requests.get(
+            f"{ECOMMERCE_API_URL}/orders/{order_id}",
+            headers={"Authorization": f"Bearer {ECOMMERCE_API_KEY}"},
+        )
+        resp.raise_for_status()
+        return resp.json()

--- a/src/tools/operations_tools/__init__.py
+++ b/src/tools/operations_tools/__init__.py
@@ -1,0 +1,6 @@
+"""Tools for logistics and warehouse operations."""
+
+__all__ = [
+    "inventory_tool",
+    "tms_tool",
+]

--- a/src/tools/operations_tools/inventory_tool.py
+++ b/src/tools/operations_tools/inventory_tool.py
@@ -1,0 +1,35 @@
+"""Simple inventory management API client."""
+
+try:
+    import requests
+except ImportError:  # pragma: no cover
+    requests = None
+
+from ...constants import INVENTORY_API_URL, INVENTORY_API_KEY
+from ...utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+class InventoryTool:
+    def update_inventory(self, item_id: str, quantity: int) -> dict:
+        logger.info(f"Updating inventory {item_id} by {quantity}")
+        if not requests:
+            raise RuntimeError("requests package is not installed")
+        resp = requests.post(
+            f"{INVENTORY_API_URL}/items/{item_id}",
+            json={"quantity": quantity},
+            headers={"Authorization": f"Bearer {INVENTORY_API_KEY}"},
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_item(self, item_id: str) -> dict:
+        logger.info(f"Fetching inventory item {item_id}")
+        if not requests:
+            raise RuntimeError("requests package is not installed")
+        resp = requests.get(
+            f"{INVENTORY_API_URL}/items/{item_id}",
+            headers={"Authorization": f"Bearer {INVENTORY_API_KEY}"},
+        )
+        resp.raise_for_status()
+        return resp.json()

--- a/src/tools/operations_tools/tms_tool.py
+++ b/src/tools/operations_tools/tms_tool.py
@@ -1,0 +1,36 @@
+"""Transportation management system API client."""
+
+try:
+    import requests
+except ImportError:  # pragma: no cover
+    requests = None
+
+from ...constants import TMS_API_URL, TMS_API_KEY
+from ...utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+class TMSTool:
+    def create_shipment(self, data: dict) -> dict:
+        logger.info("Creating shipment in TMS")
+        if not requests:
+            raise RuntimeError("requests package is not installed")
+        resp = requests.post(
+            f"{TMS_API_URL}/shipments",
+            json=data,
+            headers={"Authorization": f"Bearer {TMS_API_KEY}"},
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def update_status(self, shipment_id: str, status: str) -> dict:
+        logger.info(f"Updating shipment {shipment_id} status to {status}")
+        if not requests:
+            raise RuntimeError("requests package is not installed")
+        resp = requests.put(
+            f"{TMS_API_URL}/shipments/{shipment_id}",
+            json={"status": status},
+            headers={"Authorization": f"Bearer {TMS_API_KEY}"},
+        )
+        resp.raise_for_status()
+        return resp.json()

--- a/tests/test_operations_agents.py
+++ b/tests/test_operations_agents.py
@@ -1,0 +1,40 @@
+from src.agents.inbound_agent import InboundAgent
+from src.agents.inventory_management_agent import InventoryManagementAgent
+from src.agents.tms_agent import TMSAgent
+
+
+def test_inbound_agent(monkeypatch):
+    class DummyTMS:
+        def create_shipment(self, data):
+            return {"id": "ship1"}
+    class DummyInv:
+        def update_inventory(self, item_id, qty):
+            return {"id": item_id, "qty": qty}
+    monkeypatch.setattr("src.tools.operations_tools.tms_tool.TMSTool", DummyTMS)
+    monkeypatch.setattr("src.tools.operations_tools.inventory_tool.InventoryTool", DummyInv)
+    agent = InboundAgent()
+    out = agent.run({"trailer_id": "T1", "items": [{"sku": "A", "qty": 2}]})
+    assert out["status"] == "inbound_processed"
+    assert out["shipment_id"] == "ship1"
+
+
+def test_inventory_management_agent(monkeypatch):
+    class DummyInv:
+        def update_inventory(self, item_id, qty):
+            return {"id": item_id, "qty": qty}
+    monkeypatch.setattr("src.tools.operations_tools.inventory_tool.InventoryTool", DummyInv)
+    agent = InventoryManagementAgent()
+    out = agent.run({"item_id": "A", "qty": 5})
+    assert out["status"] == "updated"
+    assert out["item_id"] == "A"
+
+
+def test_tms_agent(monkeypatch):
+    class DummyTMS:
+        def update_status(self, sid, status):
+            return {"ok": True}
+    monkeypatch.setattr("src.tools.operations_tools.tms_tool.TMSTool", DummyTMS)
+    agent = TMSAgent()
+    out = agent.run({"shipment_id": "S1", "status": "delivered"})
+    assert out["status"] == "updated"
+    assert out["shipment_id"] == "S1"


### PR DESCRIPTION
## Summary
- extend constants with logistics and ecommerce API settings
- add tools for inventory, TMS and ecommerce integrations
- implement logistics agents (inbound/outbound, inventory, TMS, fulfillment, ecommerce, on-road)
- expose new agents from package
- add operation focused team JSON definitions
- document operations and fulfillment teams in README
- test new agents

## Testing
- `pytest -q`

------
