### PR TITLE
Add procurement agent and supplier adapters

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -40,6 +40,7 @@ __all__ = [
     'FulfillmentAgent',
     'OnRoadAgent',
     'EcommerceAgent',
+    'ProcurementAgent',
     'SupportAgent',
 ]
 
@@ -79,6 +80,7 @@ _module_map: Dict[str, str] = {
     'FulfillmentAgent': 'fulfillment_agent',
     'OnRoadAgent': 'on_road_agent',
     'EcommerceAgent': 'ecommerce_agent',
+    'ProcurementAgent': 'procurement_agent',
     'SupportAgent': 'support_agent',
 }
 

--- a/src/agents/procurement_agent.py
+++ b/src/agents/procurement_agent.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+"""Agent for automating material purchasing decisions."""
+
+import json
+from decimal import Decimal
+from typing import Iterable, List
+
+from agentic_core import AbstractAgent, EventBus
+from ..suppliers import BaseSupplierAdapter, Quote
+from ..utils.logger import get_logger
+from ..constants import OPENAI_API_KEY
+
+try:
+    import openai
+except ImportError:  # pragma: no cover - optional dependency
+    openai = None
+
+logger = get_logger(__name__)
+
+MAX_AUTO_APPROVAL = Decimal("50000")
+
+EVALUATE_PROMPT = (
+    "Given the following supplier quotes for {qty} x {item}:\n"
+    "{quotes}\n"
+    "Select the best supplier that meets the target of {target_days} days. "
+    "Respond in JSON as {{\"supplier_id\": \"...\", \"reason\": \"...\", "
+    "\"requires_approval\": false}}."
+)
+
+
+class ProcurementAgent(AbstractAgent):
+    """Subscribe to material requests and automate purchasing."""
+
+    def __init__(
+        self,
+        bus: EventBus,
+        suppliers: Iterable[BaseSupplierAdapter],
+    ) -> None:
+        super().__init__("Procurement")
+        self.bus = bus
+        self.suppliers: List[BaseSupplierAdapter] = list(suppliers)
+        if openai:
+            openai.api_key = OPENAI_API_KEY
+        self.bus.subscribe("Project.MaterialsNeeded", self.run)
+
+    def _format_prompt(
+        self, item: str, qty: int, target_days: int, quotes: List[Quote]
+    ) -> str:
+        lines = [
+            f"- {q.supplier_id}: ${q.price} in {q.delivery_days} days" for q in quotes
+        ]
+        return EVALUATE_PROMPT.format(
+            item=item,
+            qty=qty,
+            target_days=target_days,
+            quotes="\n".join(lines),
+        )
+
+    def _gpt_decide(self, prompt: str) -> dict:
+        if not openai:
+            raise RuntimeError("openai package is not installed")
+        resp = openai.ChatCompletion.create(
+            model="gpt-4",
+            messages=[{"role": "user", "content": prompt}],
+            timeout=10,
+        )
+        return json.loads(resp.choices[0].message.content)
+
+    def place_order(self, quote: Quote, item: str, qty: int) -> str:
+        logger.info(
+            f"Placing order with {quote.supplier_id} for {qty} {item} at ${quote.price}"
+        )
+        return "PO-0001"
+
+    def run(self, payload: dict) -> dict:
+        item = payload.get("item")
+        qty = int(payload.get("qty", 0))
+        target_days = int(payload.get("target_days", 0))
+
+        quotes = [s.get_quote(item, qty) for s in self.suppliers]
+        valid = [q for q in quotes if q.delivery_days <= target_days]
+        cheapest = min(valid or quotes, key=lambda q: q.price)
+
+        try:
+            decision = self._gpt_decide(self._format_prompt(item, qty, target_days, quotes))
+            supplier_id = decision.get("supplier_id", cheapest.supplier_id)
+            reason = decision.get("reason", "")
+            requires_approval = bool(decision.get("requires_approval", False))
+            chosen = next((q for q in quotes if q.supplier_id == supplier_id), cheapest)
+        except Exception as exc:  # pragma: no cover - network failures
+            logger.warning(f"GPT evaluation failed: {exc}")
+            chosen = cheapest
+            reason = "Selected cheapest available supplier."
+            requires_approval = False
+
+        if chosen.price > MAX_AUTO_APPROVAL:
+            requires_approval = True
+
+        event = {
+            "supplier_id": chosen.supplier_id,
+            "item": item,
+            "qty": qty,
+            "price": str(chosen.price),
+            "reason": reason,
+        }
+
+        if requires_approval:
+            self.bus.publish("Procurement.PendingApproval", event)
+            return {"status": "pending_approval", **event}
+
+        order_id = self.place_order(chosen, item, qty)
+        out_event = {**event, "order_id": order_id}
+        self.bus.publish("Procurement.Ordered", out_event)
+        return {"status": "ordered", **out_event}

--- a/src/suppliers.py
+++ b/src/suppliers.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+"""Supplier adapter interfaces for :class:`ProcurementAgent`."""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from decimal import Decimal
+import random
+
+
+@dataclass
+class Quote:
+    """Represent a supplier quote."""
+
+    supplier_id: str
+    price: Decimal
+    delivery_days: int
+
+
+class BaseSupplierAdapter(ABC):
+    """Abstract supplier interface used by :class:`ProcurementAgent`."""
+
+    supplier_id: str
+
+    @abstractmethod
+    def get_quote(self, item: str, qty: int) -> Quote:
+        """Return a :class:`Quote` for ``item`` and ``qty``."""
+
+
+class AcmeCement(BaseSupplierAdapter):
+    """Dummy supplier returning random prices for cement."""
+
+    supplier_id = "acme_cement"
+
+    def get_quote(self, item: str, qty: int) -> Quote:
+        price = Decimal(random.randint(95, 105)) * qty
+        days = random.randint(3, 7)
+        return Quote(self.supplier_id, price, days)
+
+
+class SteelCorp(BaseSupplierAdapter):
+    """Dummy supplier returning random prices for steel."""
+
+    supplier_id = "steel_corp"
+
+    def get_quote(self, item: str, qty: int) -> Quote:
+        price = Decimal(random.randint(80, 110)) * qty
+        days = random.randint(5, 10)
+        return Quote(self.supplier_id, price, days)

--- a/tests/test_procurement_agent.py
+++ b/tests/test_procurement_agent.py
@@ -1,0 +1,53 @@
+from decimal import Decimal
+
+from agentic_core import EventBus
+
+from src.suppliers import BaseSupplierAdapter, Quote
+from src.agents.procurement_agent import ProcurementAgent, MAX_AUTO_APPROVAL
+
+
+class DummySupplier(BaseSupplierAdapter):
+    def __init__(self, supplier_id: str, price: str, days: int) -> None:
+        self.supplier_id = supplier_id
+        self._price = Decimal(price)
+        self._days = days
+
+    def get_quote(self, item: str, qty: int) -> Quote:
+        return Quote(self.supplier_id, self._price * qty, self._days)
+
+
+def test_auto_order(monkeypatch):
+    bus = EventBus()
+    ordered = []
+    bus.subscribe("Procurement.Ordered", ordered.append)
+
+    s1 = DummySupplier("s1", "100", 5)
+    s2 = DummySupplier("s2", "120", 6)
+    agent = ProcurementAgent(bus, [s1, s2])
+    monkeypatch.setattr(agent, "_gpt_decide", lambda prompt: {
+        "supplier_id": "s1",
+        "reason": "lowest",
+        "requires_approval": False,
+    })
+
+    result = agent.run({"item": "cement", "qty": 10, "target_days": 7})
+    assert result["status"] == "ordered"
+    assert ordered[0]["supplier_id"] == "s1"
+
+
+def test_needs_approval(monkeypatch):
+    bus = EventBus()
+    pending = []
+    bus.subscribe("Procurement.PendingApproval", pending.append)
+
+    s1 = DummySupplier("s1", "6000", 5)
+    agent = ProcurementAgent(bus, [s1])
+    monkeypatch.setattr(agent, "_gpt_decide", lambda prompt: {
+        "supplier_id": "s1",
+        "reason": "expensive",
+        "requires_approval": True,
+    })
+
+    result = agent.run({"item": "steel", "qty": 10, "target_days": 7})
+    assert result["status"] == "pending_approval"
+    assert Decimal(pending[0]["price"]) > MAX_AUTO_APPROVAL


### PR DESCRIPTION
## Summary
- add supplier adapter abstractions with dummy suppliers
- implement `ProcurementAgent` that automates purchasing decisions
- expose new agent via package init
- unit tests for procurement workflow

## Testing
- `pytest -q`

------
