### PR TITLE
Implement RevOps agent and new orchestrator wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ Welcome to the Brookside BI Agentic System! This repo contains a modular, turn-b
 │   ├── agents/                # Core agent implementations
 │   ├── tools/                 # Reusable utilities used by agents
 │   ├── constants.py           # Env vars & API keys
+│   ├── orchestrator.py        # Event bus wiring
+│   ├── crm_connector.py       # CRM interface stubs
+│   ├── dev_assist.py          # Boilerplate generator
+│   ├── debugger_agent.py      # Auto patch suggestions
+│   ├── qa_agent.py            # Conversation tester
 │   └── teams/                 # RoundRobinGroupChat definitions
 ├── tests/                     # pytest suite
 └── README.md                  # You are here!
@@ -54,3 +59,18 @@ pip install -r requirements.txt
 ```
 
 The optional packages listed in that file (such as `openai` and `google-api-python-client`) are not needed when running the unit tests but enable additional runtime integrations.
+
+## 📊 RevOps & Tooling
+
+Recent updates introduce a `RevOpsAgent` that summarizes CRM pipeline KPIs and
+publishes revenue forecasts. The orchestrator wires this agent into a global
+`EventBus` and triggers it on a monthly cron tick. Several internal utilities are
+also included:
+
+* `dev_assist.py` – generate boilerplate modules and matching tests.
+* `debugger_agent.py` – listen for `*.Error` events and propose patches.
+* `qa_agent.py` – run scripted conversations against `SupportAgent` and emit QA
+  reports.
+
+These helper scripts keep network calls behind feature flags so they remain
+test-safe by default.

--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -42,6 +42,7 @@ __all__ = [
     'EcommerceAgent',
     'ProcurementAgent',
     'SupportAgent',
+    'RevOpsAgent',
 ]
 
 _module_map: Dict[str, str] = {
@@ -82,6 +83,7 @@ _module_map: Dict[str, str] = {
     'EcommerceAgent': 'ecommerce_agent',
     'ProcurementAgent': 'procurement_agent',
     'SupportAgent': 'support_agent',
+    'RevOpsAgent': 'revops_agent',
 }
 
 

--- a/src/agents/revops_agent.py
+++ b/src/agents/revops_agent.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+"""Revenue operations agent producing pipeline forecasts."""
+
+import json
+from dataclasses import dataclass
+from typing import List
+
+from agentic_core import AbstractAgent, EventBus
+
+from ..crm_connector import Deal, fetch_deals
+from ..utils.logger import get_logger
+from ..constants import OPENAI_API_KEY
+
+try:  # pragma: no cover - optional dependency
+    import openai
+except Exception:  # pragma: no cover - optional dependency
+    openai = None
+
+logger = get_logger(__name__)
+
+STALE_DAYS = 30
+
+
+@dataclass
+class KPI:
+    total_pipeline: float
+    avg_cycle_time: float
+    stalled_count: int
+
+
+class RevOpsAgent(AbstractAgent):
+    """Respond to ``RevOps.Analyze`` events with deal forecasts."""
+
+    def __init__(self, bus: EventBus) -> None:
+        super().__init__("revops")
+        self.bus = bus
+        if openai:
+            openai.api_key = OPENAI_API_KEY
+        self.bus.subscribe("RevOps.Analyze", self.run)
+
+    def _summarize_kpis(self, deals: List[Deal]) -> KPI:
+        if not deals:
+            return KPI(0.0, 0.0, 0)
+        total = sum(d.amount for d in deals)
+        avg_cycle = sum(d.days_in_stage for d in deals) / len(deals)
+        stalled = sum(1 for d in deals if d.days_in_stage > STALE_DAYS)
+        return KPI(total, avg_cycle, stalled)
+
+    def _ask_gpt(self, prompt: str) -> dict:
+        if not openai:
+            raise RuntimeError("openai package is not installed")
+        resp = openai.ChatCompletion.create(
+            model="gpt-4",
+            messages=[{"role": "user", "content": prompt}],
+            timeout=10,
+        )
+        return json.loads(resp.choices[0].message.content)
+
+    def run(self, payload: dict) -> dict:
+        tenant = payload.get("tenant_id")
+        deals = fetch_deals(tenant)
+        kpi = self._summarize_kpis(deals)
+        prompt = (
+            f"Total pipeline ${kpi.total_pipeline:.2f}, avg cycle {kpi.avg_cycle_time:.1f} days, "
+            f"stalled {kpi.stalled_count}. Forecast Q(close -> revenue) and top 3 risks "
+            f"& recommended next actions (JSON)."
+        )
+        try:
+            analysis = self._ask_gpt(prompt)
+        except Exception as exc:  # pragma: no cover - network failures
+            logger.warning(f"GPT analysis failed: {exc}")
+            analysis = {"forecast": "unknown", "risks": [], "actions": []}
+
+        report = {
+            "tenant": tenant,
+            "forecast": analysis.get("forecast"),
+            "risks": analysis.get("risks", []),
+            "actions": analysis.get("actions", []),
+        }
+        self.bus.publish("RevOps.Report", report)
+        return report

--- a/src/crm_connector.py
+++ b/src/crm_connector.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class Deal:
+    """Minimal CRM deal representation used by RevOpsAgent."""
+
+    id: str
+    amount: float
+    stage: str
+    days_in_stage: int
+    last_touch: str
+    probability: float
+
+
+def fetch_deals(tenant_id: str) -> List[Deal]:
+    """Return deals for ``tenant_id``.
+
+    This stub simply returns an empty list and should be replaced by a real CRM
+    connector in production.
+    """
+    return []

--- a/src/debugger_agent.py
+++ b/src/debugger_agent.py
@@ -1,0 +1,52 @@
+"""Agent that proposes fixes when errors occur."""
+
+from __future__ import annotations
+
+import json
+from agentic_core import AbstractAgent, EventBus
+from .utils.logger import get_logger
+
+try:  # pragma: no cover - optional dependency
+    import openai
+except Exception:  # pragma: no cover - optional dependency
+    openai = None
+
+GITHUB_ENABLED = False
+logger = get_logger(__name__)
+
+
+def open_pr(diff: str) -> None:  # pragma: no cover - placeholder
+    if not GITHUB_ENABLED:
+        return
+    # Real implementation would call GitHub API
+    logger.info("Would open PR with diff:\n%s", diff)
+
+
+class DebuggerAgent(AbstractAgent):
+    """Listen for ``*.Error`` events and suggest patches."""
+
+    def __init__(self, bus: EventBus) -> None:
+        super().__init__("debugger")
+        self.bus = bus
+        self.bus.subscribe("Error", self.run)
+
+    def _ask_gpt(self, context: str) -> str:
+        if not openai:
+            raise RuntimeError("openai package is not installed")
+        resp = openai.ChatCompletion.create(
+            model="gpt-4",
+            messages=[{"role": "user", "content": context}],
+            timeout=10,
+        )
+        return resp.choices[0].message.content
+
+    def run(self, payload: dict) -> dict:
+        context = payload.get("trace", "")
+        try:
+            diff = self._ask_gpt(context)
+        except Exception as exc:  # pragma: no cover - network failures
+            logger.warning(f"Debugger GPT failed: {exc}")
+            diff = ""
+        if GITHUB_ENABLED and diff:
+            open_pr(diff)
+        return {"diff": diff}

--- a/src/dev_assist.py
+++ b/src/dev_assist.py
@@ -1,0 +1,26 @@
+"""Simple developer helper for generating boilerplate files."""
+
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("Usage: python dev_assist.py 'Describe component'")
+        return
+    desc = sys.argv[1]
+    name = desc.lower().replace(" ", "_")
+    code_file = Path(f"src/{name}.py")
+    test_file = Path(f"tests/test_{name}.py")
+
+    if not code_file.exists():
+        code_file.write_text(f'"""TODO: {desc}."""\n')
+    if not test_file.exists():
+        test_file.write_text(
+            '"""Tests for {name}"""\n\n\n' 'def test_placeholder():\n    assert True\n'
+        )
+    print(f"Created {code_file} and {test_file}")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual utility
+    main()

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -15,7 +15,14 @@ might hook up multiple agents without including any heavy framework code or
 infrastructure specific details.
 """
 
-from typing import Dict, Any
+from typing import Dict, Any, List
+
+try:  # pragma: no cover - optional dependency
+    import openai
+except Exception:  # pragma: no cover - optional dependency
+    openai = None
+
+from agentic_core import EventBus
 
 from .agents.lead_capture_agent import LeadCaptureAgent
 from .agents.chatbot_agent import ChatbotAgent
@@ -23,9 +30,39 @@ from .agents.crm_pipeline_agent import CRMPipelineAgent
 from .agents.segmentation_ad_targeting_agent import SegmentationAdTargetingAgent
 from .memory_service import MemoryService
 from .utils.logger import get_logger
+from .agents.support_agent import SupportAgent
+from .agents.procurement_agent import ProcurementAgent
+from .agents.revops_agent import RevOpsAgent
 
 
 logger = get_logger(__name__)
+
+USE_LLM_PLANNER = False
+
+
+def gpt_plan(goal: str, available_events: List[str]) -> str:
+    """Plan next action using GPT given a goal and events."""
+    if not openai:
+        raise RuntimeError("openai package is not installed")
+    resp = openai.ChatCompletion.create(
+        model="gpt-4",
+        messages=[{"role": "user", "content": f"{goal}\nEvents: {available_events}"}],
+        timeout=10,
+    )
+    return resp.choices[0].message.content
+
+
+class _SupportTools:
+    """Minimal toolbox used for SupportAgent demos."""
+
+    def lookup_order(self, order_id: str) -> dict:  # pragma: no cover - demo stub
+        return {"status": "shipped", "days_delayed": 0}
+
+    def issue_refund(self, order_id: str, pct: int) -> str:  # pragma: no cover - demo stub
+        return "r1"
+
+    def create_ticket(self, summary: str, customer_id: str) -> str:  # pragma: no cover - demo stub
+        return "t1"
 
 
 class Orchestrator:
@@ -37,9 +74,12 @@ class Orchestrator:
         URL of the memory service used to persist and retrieve events.
     """
 
-    def __init__(self, memory_endpoint: str):
+    def __init__(self, memory_endpoint: str, use_llm_planner: bool = False):
         # the in-memory storage (could be a vector DB or search engine)
         self.memory = MemoryService(memory_endpoint)
+
+        self.bus = EventBus()
+        self.use_llm_planner = use_llm_planner
 
         # Register a very small set of agents keyed by event type.  In a real
         # system this might be configurable or use entry points/plugins.
@@ -50,6 +90,38 @@ class Orchestrator:
             "crm_pipeline": CRMPipelineAgent(),
             "segmentation": SegmentationAdTargetingAgent(),
         }
+
+        # Additional global agents used outside of handle_event
+        self.support = SupportAgent(
+            "demo", self.memory, self.bus, toolbox=_SupportTools()
+        )
+        self.procurement = ProcurementAgent(self.bus, suppliers=[])
+        self.revops = RevOpsAgent(self.bus)
+
+        # planning logic wiring
+        self.bus.subscribe("Lead.Won", self._on_lead_won)
+        self.bus.subscribe(
+            "Project.MaterialsNeeded.Resolved", self._on_materials_resolved
+        )
+
+    # --- planning callbacks -------------------------------------------------
+
+    def _on_lead_won(self, payload: dict) -> None:
+        """Trigger material planning after a lead is won."""
+        if USE_LLM_PLANNER:
+            try:
+                gpt_plan("plan materials", ["Project.MaterialsNeeded"])
+            except Exception as exc:  # pragma: no cover - network failures
+                logger.warning(f"LLM planner failed: {exc}")
+        self.bus.publish("Project.MaterialsNeeded", payload)
+
+    def _on_materials_resolved(self, payload: dict) -> None:
+        """Schedule project kickoff once materials are procured."""
+        self.bus.publish("Email.SendKickoff", {"project_id": payload.get("project_id")})
+
+    def monthly_tick(self) -> None:
+        """Emit the RevOps analysis cron event."""
+        self.bus.publish("RevOps.Analyze", {"tenant_id": "demo"})
 
     def handle_event(self, event: Dict[str, Any]) -> Dict[str, Any]:
         """Persist the event and delegate handling to an agent.

--- a/src/qa_agent.py
+++ b/src/qa_agent.py
@@ -1,0 +1,33 @@
+"""QA agent validating SupportAgent conversations."""
+
+from __future__ import annotations
+
+import json
+from agentic_core import AbstractAgent, EventBus
+from .agents.support_agent import SupportAgent
+from .utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class QAAgent(AbstractAgent):
+    """Run scripted conversations and emit QA results."""
+
+    def __init__(self, bus: EventBus, support_agent: SupportAgent) -> None:
+        super().__init__("qa")
+        self.bus = bus
+        self.support = support_agent
+        self.bus.subscribe("QA.Run", self.run)
+
+    def run(self, payload: dict) -> dict:
+        scripts = payload.get("scripts", [])
+        passed = True
+        for msg in scripts:
+            reply = self.support.run(msg)
+            try:
+                json.dumps(reply)
+            except Exception:
+                passed = False
+        result = {"passed": passed}
+        self.bus.publish("QA.Report", result)
+        return result

--- a/tests/test_revops_agent.py
+++ b/tests/test_revops_agent.py
@@ -1,0 +1,28 @@
+from agentic_core import EventBus
+
+from src.crm_connector import Deal
+from src.agents.revops_agent import RevOpsAgent
+
+
+def test_revops_agent(monkeypatch):
+    bus = EventBus()
+    reports = []
+    bus.subscribe("RevOps.Report", reports.append)
+
+    deals = [
+        Deal("d1", 1000, "Negotiate", 5, "2025-06-01", 0.6),
+        Deal("d2", 2000, "Proposal", 40, "2025-06-02", 0.5),
+    ]
+    monkeypatch.setattr("src.crm_connector.fetch_deals", lambda tid: deals)
+
+    agent = RevOpsAgent(bus)
+    monkeypatch.setattr(agent, "_ask_gpt", lambda prompt: {
+        "forecast": "$3k",
+        "risks": ["stall"],
+        "actions": ["email"],
+    })
+
+    out = agent.run({"tenant_id": "t1"})
+    assert out["forecast"] == "$3k"
+    assert reports[0]["actions"] == ["email"]
+


### PR DESCRIPTION
## Summary
- add RevOpsAgent with CRM connector stub
- wire Support, Procurement and RevOps agents into orchestrator with optional LLM planning
- provide developer helper tools: dev_assist, debugger_agent, qa_agent
- add tests for RevOpsAgent
- document new RevOps agent and internal tooling

## Testing
- `pytest -q`


------
