### PR TITLE
Improve documentation and add license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Brookside BI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/components.md
+++ b/docs/components.md
@@ -1,0 +1,54 @@
+# Component Guide
+
+This guide describes the main modules that make up the Brookside BI agent system. Use it alongside `architecture.md` to understand how everything fits together.
+
+## Orchestrators
+
+Three orchestrators coordinate agent behavior:
+
+* **`Orchestrator`** – the entry point for single-team workflows. Events are stored via the `MemoryService` and then routed to a specific agent based on the event `type`.
+* **`TeamOrchestrator`** – loads an AutoGen team from JSON. Each participant becomes an AutoGen agent bound to a shared `EventBus`. This orchestrator exposes `handle_event()` to push messages into the chat loop.
+* **`SolutionOrchestrator`** – manages multiple `TeamOrchestrator` instances. It accepts a mapping of team names to JSON paths and forwards events accordingly.
+
+## Memory Services
+
+The `MemoryService` abstraction allows the orchestrators to persist conversation history. Two variants are available:
+
+1. `agentic_core.MemoryService` – an in-memory store used for local tests.
+2. `src.memory_service.MemoryService` – a thin REST client calling `/store` and `/fetch` endpoints as shown in `architecture.md`.
+
+The implementation can be swapped at runtime so your agents can persist data to any backend.
+
+## Agents
+
+Agents live under `src/agents/` and are simple Python classes with a `run()` method. Many derive from a small `BaseAgent` helper that handles event subscription. Examples include:
+
+* `ChatbotAgent` – responds to user queries.
+* `LeadCaptureAgent` – parses forms and enters prospects into the CRM.
+* `ProcurementAgent` – manages supplier quotes and approvals.
+
+When AutoGen is used, these classes provide the business logic invoked by the AutoGen participants defined in your team JSON.
+
+## Tools
+
+Reusable utilities live under `src/tools/`. They encapsulate third-party integrations or shared logic, for example:
+
+* `crm_tool.py` – generic CRM operations such as creating contacts or updating deals.
+* `real_estate_tools.py` – fetch MLS data and post listings.
+* `ecommerce_tool.py` – manage product catalogs and shopping carts.
+
+Tool classes can be registered as `FunctionTool` entries in a team JSON file so agents can call them during a conversation.
+
+## EventBus
+
+An in-memory publish/subscribe mechanism. Agents and orchestrators subscribe to topics and publish events to coordinate asynchronous workflows. The bus keeps all components loosely coupled.
+
+## Adding New Functionality
+
+1. Create an agent under `src/agents/` implementing the desired behavior.
+2. Optionally build helper functions under `src/tools/`.
+3. Add a team JSON file referencing your agent and tools.
+4. Register the team with `SolutionOrchestrator` and send it events.
+
+These steps let you compose new business flows without touching the core orchestrator logic.
+


### PR DESCRIPTION
## Summary
- add a Quick Start section to the README
- document optional dependencies and environment variables
- show an example team JSON snippet
- include testing instructions and MIT license notice
- add an architecture diagram and MemoryService HTTP examples
- add LICENSE file
- expand README with a guide on creating custom teams and link to a new component guide
- document advanced customization options

## Testing
- `pytest -q`


------
