### PR TITLE
Add configurable agent loading for Orchestrator

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,6 +61,16 @@ GET /fetch?key=lead_capture:42&top_k=5
 ### Orchestrator
 
 `src.orchestrator.Orchestrator` wires a handful of Python agents together.  `handle_event()` stores incoming payloads via `MemoryService` and then calls the agent associated with the event `type`.
+The mapping of event types to agent classes can be supplied via a small JSON file. When the orchestrator is constructed with ``config_path`` it loads this file and imports the listed modules dynamically. An example can be found in ``src/orchestrator_config.json``:
+
+```json
+{
+  "lead_capture": "src.agents.lead_capture_agent.LeadCaptureAgent",
+  "chatbot": "src.agents.chatbot_agent.ChatbotAgent"
+}
+```
+
+If ``config_path`` is not provided, a built-in default mapping identical to the example above is used.
 
 ### TeamOrchestrator
 

--- a/src/orchestrator_config.json
+++ b/src/orchestrator_config.json
@@ -1,0 +1,6 @@
+{
+  "lead_capture": "src.agents.lead_capture_agent.LeadCaptureAgent",
+  "chatbot": "src.agents.chatbot_agent.ChatbotAgent",
+  "crm_pipeline": "src.agents.crm_pipeline_agent.CRMPipelineAgent",
+  "segmentation": "src.agents.segmentation_ad_targeting_agent.SegmentationAdTargetingAgent"
+}

--- a/tests/test_orchestrator_config.py
+++ b/tests/test_orchestrator_config.py
@@ -1,0 +1,46 @@
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from src.orchestrator import Orchestrator
+from src.agents.base_agent import BaseAgent
+
+
+class DummyAgentA(BaseAgent):
+    def run(self, payload):
+        return {"handled": "A"}
+
+
+class DummyAgentB(BaseAgent):
+    def run(self, payload):
+        return {"handled": "B"}
+
+
+def test_load_agents_from_config(tmp_path: Path):
+    cfg = {
+        "a": "src.agents.dummy_agent_a.DummyAgentA",
+        "b": "src.agents.dummy_agent_b.DummyAgentB",
+    }
+    cfg_path = tmp_path / "cfg.json"
+    cfg_path.write_text(json.dumps(cfg))
+
+    mod_a = types.ModuleType("src.agents.dummy_agent_a")
+    mod_a.DummyAgentA = DummyAgentA
+    sys.modules["src.agents.dummy_agent_a"] = mod_a
+
+    mod_b = types.ModuleType("src.agents.dummy_agent_b")
+    mod_b.DummyAgentB = DummyAgentB
+    sys.modules["src.agents.dummy_agent_b"] = mod_b
+
+    orch = Orchestrator("http://mem", config_path=str(cfg_path))
+
+    assert set(orch.agents.keys()) == {"a", "b"}
+    assert isinstance(orch.agents["a"], DummyAgentA)
+    assert isinstance(orch.agents["b"], DummyAgentB)
+
+    out = orch.handle_event({"type": "a", "payload": {}})
+    assert out["status"] == "done"
+    assert out["result"] == {"handled": "A"}


### PR DESCRIPTION
## Summary
- introduce `orchestrator_config.json` listing default event-to-agent mappings
- load agent mapping dynamically in `Orchestrator` when `config_path` is given
- document configuration file in architecture docs
- add regression test verifying dynamic agent loading

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68539cc0632c832bbda97ea4f14b075a