### PR TITLE
Add AsyncEventBus and async orchestrators

### DIFF
--- a/src/qa_agent.py
+++ b/src/qa_agent.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from agentic_core import AbstractAgent, EventBus
+from agentic_core import AbstractAgent, EventBus, AsyncEventBus, run_maybe_async, run_sync
 from .agents.support_agent import SupportAgent
 from .utils.logger import get_logger
 
@@ -13,21 +13,25 @@ logger = get_logger(__name__)
 class QAAgent(AbstractAgent):
     """Run scripted conversations and emit QA results."""
 
-    def __init__(self, bus: EventBus, support_agent: SupportAgent) -> None:
+    def __init__(self, bus: EventBus | AsyncEventBus, support_agent: SupportAgent) -> None:
         super().__init__("qa")
         self.bus = bus
         self.support = support_agent
         self.bus.subscribe("QA.Run", self.run)
 
-    def run(self, payload: dict) -> dict:
+    async def run(self, payload: dict) -> dict:
         scripts = payload.get("scripts", [])
         passed = True
         for msg in scripts:
-            reply = self.support.run(msg)
+            reply = await run_maybe_async(self.support.run, msg)
             try:
                 json.dumps(reply)
             except Exception:
                 passed = False
         result = {"passed": passed}
-        self.bus.publish("QA.Report", result)
+        await run_maybe_async(self.bus.publish, "QA.Report", result)
         return result
+
+    def run_sync(self, payload: dict) -> dict:
+        """Compatibility wrapper running :meth:`run` synchronously."""
+        return run_sync(self.run(payload))

--- a/src/solution_orchestrator.py
+++ b/src/solution_orchestrator.py
@@ -17,14 +17,20 @@ class SolutionOrchestrator:
         self.history: list[dict] = []
         self.status: Dict[str, str] = {}
 
-    def handle_event(self, team: str, event: Dict[str, Any]) -> Dict[str, Any]:
+    async def handle_event(self, team: str, event: Dict[str, Any]) -> Dict[str, Any]:
         """Forward ``event`` to ``team`` and record the result."""
         orchestrator = self.teams.get(team)
         if not orchestrator:
             return {"status": "unknown_team"}
-        result = orchestrator.handle_event(event)
+        result = await orchestrator.handle_event(event)
         self.history.append({"team": team, "event": event, "result": result})
         return result
+
+    def handle_event_sync(self, team: str, event: Dict[str, Any]) -> Dict[str, Any]:
+        """Synchronous wrapper around :meth:`handle_event`."""
+        from agentic_core import run_sync
+
+        return run_sync(self.handle_event(team, event))
 
     def report_status(self, team: str, state: str) -> None:
         """Store status updates from team orchestrators."""

--- a/src/team_orchestrator.py
+++ b/src/team_orchestrator.py
@@ -7,7 +7,7 @@ import json
 from pathlib import Path
 from typing import Any, Dict
 
-from agentic_core import EventBus
+from agentic_core import EventBus, AsyncEventBus
 
 from .base_orchestrator import BaseOrchestrator
 
@@ -15,7 +15,7 @@ from .base_orchestrator import BaseOrchestrator
 class TeamOrchestrator(BaseOrchestrator):
     """Load a team config and delegate events to its agents."""
 
-    def __init__(self, config_path: str) -> None:
+    def __init__(self, config_path: str, bus: EventBus | AsyncEventBus | None = None) -> None:
         """Initialise the orchestrator from a team JSON file.
 
         Parameters
@@ -31,14 +31,14 @@ class TeamOrchestrator(BaseOrchestrator):
         At construction time every participant listed in the JSON is imported
         dynamically using :func:`importlib.import_module`. The orchestrator then
         instantiates the corresponding agent classes and registers them on an
-        internal :class:`EventBus` for message routing.
+        internal event bus (:class:`EventBus` or :class:`AsyncEventBus`) for message routing.
         """
         self.config_path = Path(config_path)
         with self.config_path.open() as fh:
             data = json.load(fh)
         participants = data.get("config", {}).get("participants", [])
 
-        bus = EventBus()
+        bus = bus or AsyncEventBus()
         super().__init__(bus=bus)
 
         for part in participants:

--- a/tests/test_async_event_bus.py
+++ b/tests/test_async_event_bus.py
@@ -1,0 +1,18 @@
+import asyncio
+from agentic_core import AsyncEventBus
+
+def test_async_event_bus_publish():
+    bus = AsyncEventBus()
+    called = []
+
+    async def handler(payload):
+        await asyncio.sleep(0.01)
+        called.append(payload)
+
+    async def main():
+        bus.subscribe("t", handler)
+        await bus.publish("t", {"x": 1})
+
+    asyncio.run(main())
+    assert called == [{"x": 1}]
+

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -82,7 +82,7 @@ def test_known_event_types(monkeypatch, event_type):
     }
 
     payload = payloads[event_type]
-    res = orch.handle_event({"type": event_type, "payload": payload})
+    res = orch.handle_event_sync({"type": event_type, "payload": payload})
 
     assert store_calls == {"key": event_type, "payload": payload}
     expected_cls = event_classes[event_type]
@@ -124,7 +124,7 @@ def test_unknown_event_type(monkeypatch):
         monkeypatch.setattr(agent, "run", make_fake(name))
 
     payload = {"foo": "bar"}
-    res = orch.handle_event({"type": "unknown", "payload": payload})
+    res = orch.handle_event_sync({"type": "unknown", "payload": payload})
 
     assert res == {"status": "ignored"}
     assert store_calls == {"key": "unknown", "payload": payload}

--- a/tests/test_orchestrator_config.py
+++ b/tests/test_orchestrator_config.py
@@ -41,6 +41,6 @@ def test_load_agents_from_config(tmp_path: Path):
     assert isinstance(orch.agents["a"], DummyAgentA)
     assert isinstance(orch.agents["b"], DummyAgentB)
 
-    out = orch.handle_event({"type": "a", "payload": {}})
+    out = orch.handle_event_sync({"type": "a", "payload": {}})
     assert out["status"] == "done"
     assert out["result"] == {"handled": "A"}

--- a/tests/test_procurement_agent.py
+++ b/tests/test_procurement_agent.py
@@ -30,7 +30,7 @@ def test_auto_order(monkeypatch):
         "requires_approval": False,
     })
 
-    result = agent.run({"item": "cement", "qty": 10, "target_days": 7})
+    result = agent.run_sync({"item": "cement", "qty": 10, "target_days": 7})
     assert result["status"] == "ordered"
     assert ordered[0]["supplier_id"] == "s1"
 
@@ -48,6 +48,6 @@ def test_needs_approval(monkeypatch):
         "requires_approval": True,
     })
 
-    result = agent.run({"item": "steel", "qty": 10, "target_days": 7})
+    result = agent.run_sync({"item": "steel", "qty": 10, "target_days": 7})
     assert result["status"] == "pending_approval"
     assert Decimal(pending[0]["price"]) > MAX_AUTO_APPROVAL

--- a/tests/test_revops_agent.py
+++ b/tests/test_revops_agent.py
@@ -1,4 +1,6 @@
-from agentic_core import EventBus
+from agentic_core import EventBus, AsyncEventBus
+import asyncio
+import pytest
 
 from src.crm_connector import Deal
 from src.agents.revops_agent import RevOpsAgent
@@ -22,7 +24,33 @@ def test_revops_agent(monkeypatch):
         "actions": ["email"],
     })
 
-    out = agent.run({"tenant_id": "t1"})
+    out = agent.run_sync({"tenant_id": "t1"})
     assert out["forecast"] == "$3k"
     assert reports[0]["actions"] == ["email"]
+
+
+def test_revops_agent_async(monkeypatch):
+    bus = AsyncEventBus()
+    reports = []
+    bus.subscribe("RevOps.Report", reports.append)
+
+    deals = [
+        Deal("d1", 1000, "Negotiate", 5, "2025-06-01", 0.6),
+        Deal("d2", 2000, "Proposal", 40, "2025-06-02", 0.5),
+    ]
+    monkeypatch.setattr("src.crm_connector.fetch_deals", lambda tid: deals)
+
+    agent = RevOpsAgent(bus)
+    monkeypatch.setattr(agent, "_ask_gpt", lambda prompt: {
+        "forecast": "$3k",
+        "risks": ["stall"],
+        "actions": ["email"],
+    })
+
+    async def main():
+        out = await agent.run({"tenant_id": "t1"})
+        assert out["forecast"] == "$3k"
+        assert reports[0]["actions"] == ["email"]
+
+    asyncio.run(main())
 

--- a/tests/test_solution_orchestrator.py
+++ b/tests/test_solution_orchestrator.py
@@ -46,8 +46,8 @@ def test_solution_orchestrator_routing(tmp_path, monkeypatch):
 
     orch = SolutionOrchestrator({"A": str(team_a), "B": str(team_b)})
 
-    out_a = orch.handle_event("A", {"type": "dummy_agent_a", "payload": {"foo": 1}})
-    out_b = orch.handle_event("B", {"type": "dummy_agent_b", "payload": {"bar": 2}})
+    out_a = orch.handle_event_sync("A", {"type": "dummy_agent_a", "payload": {"foo": 1}})
+    out_b = orch.handle_event_sync("B", {"type": "dummy_agent_b", "payload": {"bar": 2}})
 
     assert out_a["result"]["handled_by"] == "A"
     assert out_b["result"]["handled_by"] == "B"

--- a/tests/test_team_orchestrator.py
+++ b/tests/test_team_orchestrator.py
@@ -29,5 +29,5 @@ def test_team_orchestrator_inherits(tmp_path):
     orch = TeamOrchestrator(str(team_cfg))
     assert issubclass(TeamOrchestrator, BaseOrchestrator)
     assert orch.memory is None
-    out = orch.handle_event({"type": "dummy_agent", "payload": {"foo": 1}})
+    out = orch.handle_event_sync({"type": "dummy_agent", "payload": {"foo": 1}})
     assert out["result"]["echo"]["foo"] == 1


### PR DESCRIPTION
## Summary
- implement AsyncEventBus with asyncio task management
- support async handling in BaseOrchestrator and derived orchestrators
- update ProcurementAgent, RevOpsAgent, SupportAgent and QAAgent to async run methods
- add compatibility wrappers for synchronous usage
- extend unit tests for async publishing and update existing tests
- document async flow in architecture guide

## Testing
- `pytest -q`

------
