### PR TITLE
Add entry point plugin loader

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -53,3 +53,20 @@ An in-memory publish/subscribe mechanism. Agents and orchestrators subscribe to 
 
 These steps let you compose new business flows without touching the core orchestrator logic.
 
+### Registering Custom Agents via Plugins
+
+Agents can also be distributed as standalone packages and discovered at runtime
+through Python entry points. Register your agent class under the
+``brookside.agents`` group in ``setup.cfg``:
+
+```ini
+[options.entry_points]
+brookside.agents =
+    lead_capture = src.agents.lead_capture_agent:LeadCaptureAgent
+```
+
+With the entry point installed, :func:`src.utils.plugin_loader.load_agent` will
+resolve ``lead_capture`` to ``LeadCaptureAgent`` without requiring explicit
+imports. The ``TeamOrchestrator`` automatically uses this loader when
+initialising agents from a team JSON file.
+

--- a/src/utils/plugin_loader.py
+++ b/src/utils/plugin_loader.py
@@ -1,0 +1,71 @@
+"""Utilities for loading agent classes from entry points or local modules."""
+
+from __future__ import annotations
+
+from importlib import import_module, metadata
+from typing import Type
+
+from ..agents.base_agent import BaseAgent
+
+
+ENTRY_POINT_GROUP = "brookside.agents"
+
+
+def _iter_entry_points(group: str):
+    """Return entry points for *group* across Python versions."""
+    try:
+        return metadata.entry_points(group=group)
+    except TypeError:  # pragma: no cover - fallback for Python <3.10
+        eps = metadata.entry_points()
+        return eps.get(group, [])
+
+
+def load_agent(name: str) -> Type[BaseAgent]:
+    """Load an agent class by ``name``.
+
+    The loader first searches registered entry points under
+    :data:`ENTRY_POINT_GROUP`. If ``name`` matches an entry point, the
+    referenced class is returned. Otherwise the loader falls back to importing
+    ``src.agents.<name>`` and resolving ``<CamelCase(name)>`` within that
+    module.
+
+    Parameters
+    ----------
+    name:
+        Entry point name or module stem of the agent.
+
+    Returns
+    -------
+    Type[BaseAgent]
+        The located agent class.
+
+    Raises
+    ------
+    ImportError
+        If no matching entry point or local module is found.
+    TypeError
+        If the resolved object is not a :class:`BaseAgent` subclass.
+    """
+    for ep in _iter_entry_points(ENTRY_POINT_GROUP):
+        if ep.name == name:
+            agent_cls = ep.load()
+            if not isinstance(agent_cls, type) or not issubclass(agent_cls, BaseAgent):
+                raise TypeError(
+                    f"Entry point '{name}' does not resolve to a BaseAgent subclass"
+                )
+            return agent_cls
+
+    try:
+        module = import_module(f"src.agents.{name}")
+    except ModuleNotFoundError as exc:
+        raise ImportError(f"Agent '{name}' not found") from exc
+
+    class_name = "".join(word.capitalize() for word in name.split("_"))
+    agent_cls = getattr(module, class_name, None)
+    if agent_cls is None:
+        raise ImportError(f"Class '{class_name}' not found in module 'src.agents.{name}'")
+
+    if not issubclass(agent_cls, BaseAgent):
+        raise TypeError(f"Class '{class_name}' is not a BaseAgent subclass")
+
+    return agent_cls

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -1,0 +1,60 @@
+import sys
+import types
+import importlib.metadata
+import pytest
+
+from src.utils.plugin_loader import load_agent
+from src.agents.base_agent import BaseAgent
+
+
+class DummyAgent(BaseAgent):
+    def run(self, payload):
+        return payload
+
+
+def test_load_agent_from_entry_point(monkeypatch):
+    mod = types.ModuleType("dummy_ep_mod")
+    mod.PluginAgent = DummyAgent
+    sys.modules["dummy_ep_mod"] = mod
+
+    ep = importlib.metadata.EntryPoint(
+        "dummy", "dummy_ep_mod:PluginAgent", "brookside.agents"
+    )
+    monkeypatch.setattr(importlib.metadata, "entry_points", lambda group=None: [ep])
+    # ensure fallback import is not used
+    monkeypatch.setattr(
+        "src.utils.plugin_loader.import_module",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("import_module called")),
+    )
+
+    cls = load_agent("dummy")
+    assert cls is DummyAgent
+
+
+def test_load_agent_fallback_to_module(monkeypatch):
+    mod = types.ModuleType("src.agents.fallback_agent")
+    mod.FallbackAgent = DummyAgent
+    sys.modules["src.agents.fallback_agent"] = mod
+
+    monkeypatch.setattr(importlib.metadata, "entry_points", lambda group=None: [])
+
+    cls = load_agent("fallback_agent")
+    assert cls is DummyAgent
+
+
+def test_load_agent_invalid_entry_point(monkeypatch):
+    class NotAgent:
+        pass
+
+    bad_mod = types.ModuleType("bad_mod")
+    bad_mod.NotAgent = NotAgent
+    sys.modules["bad_mod"] = bad_mod
+
+    ep = importlib.metadata.EntryPoint(
+        "bad", "bad_mod:NotAgent", "brookside.agents"
+    )
+    monkeypatch.setattr(importlib.metadata, "entry_points", lambda group=None: [ep])
+
+    with pytest.raises(TypeError):
+        load_agent("bad")
+


### PR DESCRIPTION
## Summary
- load agents via `brookside.agents` entry points
- use new loader in `TeamOrchestrator`
- document plugin registration and usage
- test plugin loader with mocked entry points

## Testing
- `pytest -q`

------
