### PR TITLE
Introduce pluggable memory service

### DIFF
--- a/src/base_orchestrator.py
+++ b/src/base_orchestrator.py
@@ -13,7 +13,7 @@ from .events import (
     SegmentationEvent,
 )
 
-from .memory_service import MemoryService
+from .memory_service.base import BaseMemoryService
 from .utils.logger import get_logger
 
 
@@ -26,7 +26,7 @@ class BaseOrchestrator:
     def __init__(
         self,
         bus: EventBus | AsyncEventBus | None = None,
-        memory: MemoryService | None = None,
+        memory: BaseMemoryService | None = None,
     ) -> None:
         self.bus = bus or AsyncEventBus()
         self.memory = memory

--- a/src/config.py
+++ b/src/config.py
@@ -124,6 +124,11 @@ class Settings(BaseSettings):
     GOOGLE_TRANSLATE_API_KEY: Optional[str] = None
     CONFIG_PATH: str = "config/playbook.yaml"
 
+    # Memory Service
+    MEMORY_BACKEND: Literal["rest", "file"] = "rest"
+    MEMORY_ENDPOINT: str = "http://localhost:8000"
+    MEMORY_FILE_PATH: str = "memory.jsonl"
+
     # Logistics & E-commerce
     TMS_API_URL: Optional[str] = None
     TMS_API_KEY: Optional[str] = None

--- a/src/memory_service.py
+++ b/src/memory_service.py
@@ -1,56 +1,8 @@
-"""Simple REST based memory service used by the orchestrator.
+"""Backward compatible import for the default REST memory service."""
 
-In a production system this component would likely talk to a vector database or
-some other specialised storage.  For the purposes of the examples and tests we
-fake this by sending HTTP requests to a configurable endpoint.
-"""
+from .memory_service.rest import RestMemoryService
 
-from typing import List, Dict, Any
-import types
+# Maintain historical name
+MemoryService = RestMemoryService
 
-try:  # optional dependency
-    import requests  # type: ignore
-except Exception:  # pragma: no cover - test environment fallback
-    requests = types.SimpleNamespace(
-        post=lambda *a, **k: types.SimpleNamespace(ok=True, json=lambda: {}),
-        get=lambda *a, **k: types.SimpleNamespace(ok=True, json=lambda: {}),
-    )
-from .utils.logger import get_logger
-
-logger = get_logger(__name__)
-
-
-class MemoryService:
-    """Thin wrapper around a REST API used for storing and retrieving events."""
-
-    def __init__(self, endpoint: str):
-        # base URL of the REST service (e.g. http://localhost:8000)
-        self.endpoint = endpoint
-
-    def store(self, key: str, payload: Dict[str, Any]) -> bool:
-        """Persist a payload under ``key``.
-
-        Parameters
-        ----------
-        key:
-            Identifier for the memory entry.
-        payload:
-            Arbitrary JSON serialisable dictionary to store.
-        """
-
-        logger.info(f"Storing memory for key={key}")
-        # In a real implementation this would be a vector DB or search-engine
-        # call.  Here we just POST to a simple REST endpoint.
-        response = requests.post(
-            f"{self.endpoint}/store", json={"key": key, "data": payload}
-        )
-        return response.ok
-
-    def fetch(self, key: str, top_k: int = 5) -> List[Dict[str, Any]]:
-        """Retrieve the ``top_k`` most relevant memories for ``key``."""
-        logger.info(f"Fetching top {top_k} memories for key={key}")
-        response = requests.get(
-            f"{self.endpoint}/fetch", params={"key": key, "top_k": top_k}
-        )
-        # graceful fallback on network errors or empty responses
-        return response.json() if response.ok else []
+__all__ = ["MemoryService", "RestMemoryService"]

--- a/src/memory_service/__init__.py
+++ b/src/memory_service/__init__.py
@@ -1,0 +1,7 @@
+"""Memory service backends providing persistent storage for events."""
+
+from .base import BaseMemoryService
+from .rest import RestMemoryService
+from .file import FileMemoryService
+
+__all__ = ["BaseMemoryService", "RestMemoryService", "FileMemoryService"]

--- a/src/memory_service/base.py
+++ b/src/memory_service/base.py
@@ -1,0 +1,18 @@
+"""Abstract interface for memory service implementations."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List
+
+
+class BaseMemoryService(ABC):
+    """Define the storage API used by orchestrators and agents."""
+
+    @abstractmethod
+    def store(self, key: str, payload: Dict[str, Any]) -> bool:
+        """Persist ``payload`` under ``key``."""
+
+    @abstractmethod
+    def fetch(self, key: str, top_k: int = 5) -> List[Dict[str, Any]]:
+        """Return up to ``top_k`` records associated with ``key``."""

--- a/src/memory_service/file.py
+++ b/src/memory_service/file.py
@@ -1,0 +1,42 @@
+"""Simple JSONL based memory service for local development."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+from .base import BaseMemoryService
+from ..utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class FileMemoryService(BaseMemoryService):
+    """Append events to a local JSONL file and read them back."""
+
+    def __init__(self, file_path: str | Path) -> None:
+        self.file_path = Path(file_path)
+        self.file_path.parent.mkdir(parents=True, exist_ok=True)
+        self.file_path.touch(exist_ok=True)
+
+    def store(self, key: str, payload: Dict[str, Any]) -> bool:
+        record = {"key": key, "data": payload}
+        with self.file_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record) + "\n")
+        logger.info(f"Stored event for key={key} in {self.file_path}")
+        return True
+
+    def fetch(self, key: str, top_k: int = 5) -> List[Dict[str, Any]]:
+        results: List[Dict[str, Any]] = []
+        if not self.file_path.exists():
+            return results
+        with self.file_path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if rec.get("key") == key:
+                    results.append(rec.get("data", {}))
+        return results[-top_k:]

--- a/src/memory_service/rest.py
+++ b/src/memory_service/rest.py
@@ -1,0 +1,40 @@
+"""REST based memory service used for demos and tests."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+import types
+
+from .base import BaseMemoryService
+from ..utils.logger import get_logger
+
+try:  # optional dependency
+    import requests  # type: ignore
+except Exception:  # pragma: no cover - test environment fallback
+    requests = types.SimpleNamespace(
+        post=lambda *a, **k: types.SimpleNamespace(ok=True, json=lambda: {}),
+        get=lambda *a, **k: types.SimpleNamespace(ok=True, json=lambda: {}),
+    )
+
+logger = get_logger(__name__)
+
+
+class RestMemoryService(BaseMemoryService):
+    """Thin wrapper around a REST API for persisting events."""
+
+    def __init__(self, endpoint: str) -> None:
+        self.endpoint = endpoint
+
+    def store(self, key: str, payload: Dict[str, Any]) -> bool:
+        logger.info(f"Storing memory for key={key}")
+        response = requests.post(
+            f"{self.endpoint}/store", json={"key": key, "data": payload}
+        )
+        return response.ok
+
+    def fetch(self, key: str, top_k: int = 5) -> List[Dict[str, Any]]:
+        logger.info(f"Fetching top {top_k} memories for key={key}")
+        response = requests.get(
+            f"{self.endpoint}/fetch", params={"key": key, "top_k": top_k}
+        )
+        return response.json() if response.ok else []

--- a/src/tools/memory_tools/memory_service.py
+++ b/src/tools/memory_tools/memory_service.py
@@ -1,5 +1,5 @@
 """Compatibility wrapper for the project-wide :class:`MemoryService`."""
 
-from ...memory_service import MemoryService
+from ...memory_service import RestMemoryService as MemoryService
 
 __all__ = ["MemoryService"]

--- a/tests/test_file_memory_service.py
+++ b/tests/test_file_memory_service.py
@@ -1,0 +1,22 @@
+import json
+from pathlib import Path
+
+from src.memory_service.file import FileMemoryService
+
+
+def test_store_and_fetch(tmp_path):
+    file_path = tmp_path / "mem.jsonl"
+    svc = FileMemoryService(file_path)
+
+    assert svc.store("a", {"foo": 1})
+    assert svc.store("a", {"bar": 2})
+    assert svc.store("b", {"baz": 3})
+
+    all_a = svc.fetch("a")
+    assert all_a == [{"foo": 1}, {"bar": 2}]
+
+    last_a = svc.fetch("a", top_k=1)
+    assert last_a == [{"bar": 2}]
+
+    none = svc.fetch("missing")
+    assert none == []

--- a/tests/test_orchestrator_file_backend.py
+++ b/tests/test_orchestrator_file_backend.py
@@ -1,0 +1,42 @@
+import types
+import sys
+
+import pytest
+
+from src.orchestrator import Orchestrator
+
+
+def test_orchestrator_file_backend(tmp_path, monkeypatch):
+    class DummyScheduler:
+        def create_event(self, cid, ev):
+            return {"id": "evt"}
+
+    monkeypatch.setattr(
+        "src.tools.scheduler_tool.SchedulerTool",
+        lambda: DummyScheduler(),
+    )
+    sys.modules.setdefault(
+        "requests",
+        types.SimpleNamespace(
+            post=lambda *a, **k: types.SimpleNamespace(ok=True, json=lambda: {}),
+            get=lambda *a, **k: types.SimpleNamespace(ok=True, json=lambda: {}),
+        ),
+    )
+
+    mem_file = tmp_path / "events.jsonl"
+    orch = Orchestrator(
+        memory_endpoint="http://unused",
+        memory_backend="file",
+        memory_file=str(mem_file),
+    )
+
+    payload = {"form_data": {}, "source": "web"}
+    res = orch.handle_event_sync({"type": "lead_capture", "payload": payload})
+    assert res["status"] == "done"
+
+    # ensure event persisted to file
+    contents = mem_file.read_text().strip().splitlines()
+    assert len(contents) == 1
+    assert "lead_capture" in contents[0]
+
+


### PR DESCRIPTION
## Summary
- define `BaseMemoryService` abstract class
- refactor REST memory service into package
- implement new `FileMemoryService`
- allow orchestrator to choose backend from config or parameters
- document new memory backends
- test file memory service and orchestrator integration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853b905fa1c832b807705d29a7f36aa