### PR TITLE
Add pre-commit and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pre-commit
+      - name: Run pre-commit
+        run: pre-commit run --all-files --show-diff-on-failure
+      - name: Run tests
+        run: pytest -q

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest -q
+        language: system
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -216,6 +216,17 @@ memory services, agents, tools and the in-memory event bus with pointers on how
 to extend them.
 [docs/agents_overview.md](docs/agents_overview.md) contains a catalog of every built-in agent and the utility modules they rely on.
 
+## 🤝 Contributing
+
+We welcome community contributions! Install the pre-commit hooks so your changes follow our formatting and style guidelines.
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+Running `pre-commit` will automatically format code with **black**, lint with **flake8**, and run the unit tests via **pytest** before each commit.
+
 ---
 
 This project is released under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- add pre-commit with black, flake8 and pytest
- run pre-commit and pytest in GitHub Actions
- document how to install the pre-commit hooks in README

## Testing
- `pytest -q`
- `pre-commit run --files README.md .pre-commit-config.yaml .github/workflows/ci.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853b92073d4832ba3a85c1593deaf4c