### PR TITLE
Add env selection in settings and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,9 +166,11 @@ The optional packages listed in that file (such as `openai` and `google-api-pyth
 
 The system relies on a number of environment variables for API keys and service
 endpoints. They are loaded via `src.config.Settings` which reads from the
-process environment or an optional `.env` file at the project root. The most
-common variables are summarised below. Any of them can be set in your shell or
-added to a `.env` file before running the orchestrator or tests.
+process environment and a dotenv file.  Set ``ENV`` to choose which file is
+loaded (`.env` for ``ENV=prod`` or `.env.<ENV>` otherwise).  You can also set
+``ENV_FILE`` to point at an explicit path.  The most common variables are
+summarised below. Any of them can be set in your shell or added to the chosen
+dotenv file before running the orchestrator or tests.
 
 | Variable | Purpose |
 |----------|---------|

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -118,7 +118,7 @@ At this point all AutoGen agents are live and waiting for events. Teams remain a
 
 Team JSON files under `src/teams/` describe `RoundRobinGroupChat` configurations.  Each agent entry specifies a `provider` such as `autogen_agentchat.agents.AssistantAgent` or `autogen_ext.models.openai.OpenAIChatCompletionClient`.  When a team is loaded, these providers are instantiated and stitched together by AutoGen.
 
-OpenAI powered components (via `OpenAIChatCompletionClient`) are created at this stage using the API keys defined in `src/constants.py` or environment variables.  Whenever an AutoGen agent needs a model response, the provider invokes the OpenAI API to generate the next message.
+OpenAI powered components (via `OpenAIChatCompletionClient`) are created using API keys provided by `src.config.settings`.  The settings object reads values from environment variables and the relevant `.env` file.  Whenever an AutoGen agent needs a model response, the provider invokes the OpenAI API to generate the next message.
 
 ### AutoGen Invocation
 

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -3,7 +3,16 @@
 This document describes every environment variable consumed in the project. The
 values live in [src/config.py](../src/config.py) and are provided by a Pydantic
 `BaseSettings` class. They can be loaded from environment variables or a local
-`.env` file.
+`.env` file.  Which file is used depends on the ``ENV`` and ``ENV_FILE``
+variables documented below.
+
+## Environment Selection
+
+- `ENV` – Defines the runtime environment. ``prod`` loads ``.env`` while any
+  other value loads ``.env.<ENV>`` (for example ``ENV=dev`` loads ``.env.dev``).
+  Defaults to ``dev``.
+- `ENV_FILE` – Explicit path to a dotenv file. When set this overrides the
+  ``ENV`` based behaviour.
 
 ## AI Providers
 - `OPENAI_API_KEY` – API key for OpenAI models.

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -27,3 +27,28 @@ def test_invalid_adyen_environment(monkeypatch):
     with pytest.raises(ValidationError):
         _reload_settings(monkeypatch, ADYEN_ENVIRONMENT="LOCAL")
     _reload_settings(monkeypatch, ADYEN_ENVIRONMENT=None)
+
+
+def test_env_file_selection(monkeypatch, tmp_path):
+    """Settings should load variables from the file chosen via ENV."""
+    from pathlib import Path
+
+    cwd = Path.cwd()
+    try:
+        # create environment-specific file
+        env_file = tmp_path / ".env.dev"
+        env_file.write_text("OPENAI_API_KEY=from_dev_file\n")
+        monkeypatch.chdir(tmp_path)
+        mod = _reload_settings(monkeypatch, ENV="dev", ENV_FILE=None)
+        assert mod.settings.OPENAI_API_KEY == "from_dev_file"
+    finally:
+        monkeypatch.chdir(cwd)
+
+
+def test_env_file_override(monkeypatch, tmp_path):
+    """ENV_FILE should override default selection logic."""
+    env_file = tmp_path / "custom.env"
+    env_file.write_text("OPENAI_API_KEY=from_override\n")
+    mod = _reload_settings(monkeypatch, ENV_FILE=str(env_file))
+    assert mod.settings.OPENAI_API_KEY == "from_override"
+    _reload_settings(monkeypatch, ENV_FILE=None, OPENAI_API_KEY=None)


### PR DESCRIPTION
## Summary
- switch to `src.config.Settings` and drop old constants references
- support `ENV`/`ENV_FILE` to pick dev or prod `.env` files
- document new env selection in README and environment docs
- update architecture notes
- test environment file logic

## Testing
- `pytest -q`

------
