### PR TITLE
Add plugin loader and tool plugin framework

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -70,3 +70,20 @@ resolve ``lead_capture`` to ``LeadCaptureAgent`` without requiring explicit
 imports. The ``TeamOrchestrator`` automatically uses this loader when
 initialising agents from a team JSON file.
 
+### Custom Tool Plugins
+
+Utility classes can be plugged in using the same mechanism. Implement a
+``BaseToolPlugin`` subclass under ``src/plugins`` or distribute it via an entry
+point in the ``brookside.plugins`` group. At runtime
+``src.utils.plugin_loader.load_plugin`` resolves the class so it can be
+instantiated by agents or orchestrators.
+
+```ini
+[options.entry_points]
+brookside.plugins =
+    email = src.plugins.email_plugin:EmailPlugin
+```
+
+Plugins placed directly in ``src/plugins/`` do not require registration and are
+automatically importable by name.
+

--- a/src/plugins/__init__.py
+++ b/src/plugins/__init__.py
@@ -1,0 +1,15 @@
+"""Plugin stubs providing tool integrations."""
+
+from .base_plugin import BaseToolPlugin
+from .email_plugin import EmailPlugin
+from .crm_plugin import CRMPlugin
+from .scraping_plugin import ScrapingPlugin
+from .cloud_docs_plugin import CloudDocsPlugin
+
+__all__ = [
+    "BaseToolPlugin",
+    "EmailPlugin",
+    "CRMPlugin",
+    "ScrapingPlugin",
+    "CloudDocsPlugin",
+]

--- a/src/plugins/base_plugin.py
+++ b/src/plugins/base_plugin.py
@@ -1,0 +1,15 @@
+"""Base interface for custom tool plugins."""
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict
+
+
+class BaseToolPlugin(ABC):
+    """Define the minimal interface for pluggable tools."""
+
+    name: str = ""
+
+    @abstractmethod
+    def execute(self, payload: Dict[str, Any]) -> Any:
+        """Run the plugin using ``payload`` and return a result."""
+        raise NotImplementedError

--- a/src/plugins/cloud_docs_plugin.py
+++ b/src/plugins/cloud_docs_plugin.py
@@ -1,0 +1,18 @@
+"""Example cloud document tool plugin."""
+
+from typing import Any, Dict
+
+from .base_plugin import BaseToolPlugin
+from ..utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class CloudDocsPlugin(BaseToolPlugin):
+    """Store or fetch documents from a cloud provider."""
+
+    name = "cloud_docs"
+
+    def execute(self, payload: Dict[str, Any]) -> Dict[str, str]:
+        logger.info("Stub cloud docs action: %s", payload)
+        return {"doc_id": "example"}

--- a/src/plugins/crm_plugin.py
+++ b/src/plugins/crm_plugin.py
@@ -1,0 +1,18 @@
+"""Example CRM tool plugin."""
+
+from typing import Any, Dict
+
+from .base_plugin import BaseToolPlugin
+from ..utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class CRMPlugin(BaseToolPlugin):
+    """Perform basic CRM operations."""
+
+    name = "crm"
+
+    def execute(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        logger.info("Stub CRM action: %s", payload)
+        return {"ok": True}

--- a/src/plugins/email_plugin.py
+++ b/src/plugins/email_plugin.py
@@ -1,0 +1,18 @@
+"""Example email tool plugin."""
+
+from typing import Any, Dict
+
+from .base_plugin import BaseToolPlugin
+from ..utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class EmailPlugin(BaseToolPlugin):
+    """Send an email using the provided payload."""
+
+    name = "email"
+
+    def execute(self, payload: Dict[str, Any]) -> bool:
+        logger.info("Stub email send: %s", payload)
+        return True

--- a/src/plugins/scraping_plugin.py
+++ b/src/plugins/scraping_plugin.py
@@ -1,0 +1,18 @@
+"""Example web scraping tool plugin."""
+
+from typing import Any, Dict
+
+from .base_plugin import BaseToolPlugin
+from ..utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class ScrapingPlugin(BaseToolPlugin):
+    """Return dummy HTML for a URL."""
+
+    name = "scraping"
+
+    def execute(self, payload: Dict[str, Any]) -> str:
+        logger.info("Stub scrape: %s", payload)
+        return "<html></html>"

--- a/tests/test_load_plugin.py
+++ b/tests/test_load_plugin.py
@@ -1,0 +1,58 @@
+import sys
+import types
+import importlib.metadata
+import pytest
+
+from src.utils.plugin_loader import load_plugin
+from src.plugins.base_plugin import BaseToolPlugin
+
+
+class DummyPlugin(BaseToolPlugin):
+    def execute(self, payload):
+        return payload
+
+
+def test_load_plugin_from_entry_point(monkeypatch):
+    mod = types.ModuleType("dummy_plugin_mod")
+    mod.Tool = DummyPlugin
+    sys.modules["dummy_plugin_mod"] = mod
+
+    ep = importlib.metadata.EntryPoint(
+        "dummy", "dummy_plugin_mod:Tool", "brookside.plugins"
+    )
+    monkeypatch.setattr(importlib.metadata, "entry_points", lambda group=None: [ep])
+    monkeypatch.setattr(
+        "src.utils.plugin_loader.import_module",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("import_module called")),
+    )
+
+    cls = load_plugin("dummy")
+    assert cls is DummyPlugin
+
+
+def test_load_plugin_fallback(monkeypatch):
+    mod = types.ModuleType("src.plugins.fallback_plugin")
+    mod.FallbackPlugin = DummyPlugin
+    sys.modules["src.plugins.fallback_plugin"] = mod
+
+    monkeypatch.setattr(importlib.metadata, "entry_points", lambda group=None: [])
+
+    cls = load_plugin("fallback_plugin")
+    assert cls is DummyPlugin
+
+
+def test_load_plugin_invalid_entry_point(monkeypatch):
+    class NotPlugin:
+        pass
+
+    mod = types.ModuleType("bad_plugin_mod")
+    mod.NotPlugin = NotPlugin
+    sys.modules["bad_plugin_mod"] = mod
+
+    ep = importlib.metadata.EntryPoint(
+        "bad", "bad_plugin_mod:NotPlugin", "brookside.plugins"
+    )
+    monkeypatch.setattr(importlib.metadata, "entry_points", lambda group=None: [ep])
+
+    with pytest.raises(TypeError):
+        load_plugin("bad")


### PR DESCRIPTION
## Summary
- extend plugin_loader with generic component loader
- add load_plugin for plugins in `src/plugins` or entry points
- implement `BaseToolPlugin` interface and example plugins
- document custom tool plugins in Component Guide
- test plugin loading behaviour

## Testing
- `pytest -q`

------
