### PR TITLE
Add FastAPI interface for SolutionOrchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,29 @@ brookside-cli send --team sales --event '{"type": "lead_capture", "payload": {"e
 brookside-cli status
 ```
 
+### 🌐 HTTP API
+
+An HTTP interface is available for programmatic access to the
+`SolutionOrchestrator`. Start the server with your team mapping and an API key:
+
+```bash
+API_AUTH_KEY=mysecret python -m src.api sales=src/teams/sales_team_full.json
+```
+
+Send an event using `curl`:
+
+```bash
+curl -H "X-API-Key: mysecret" \
+     -X POST http://localhost:8000/teams/sales/event \
+     -d '{"type": "lead_capture", "payload": {"email": "alice@example.com"}}'
+```
+
+Fetch the latest status:
+
+```bash
+curl -H "X-API-Key: mysecret" http://localhost:8000/teams/sales/status
+```
+
 ### 🌟 Creating Custom Teams
 
 To design your own workflow start with one of the JSON files under

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -129,3 +129,4 @@ variables documented below.
 ## Utility Services
 - `GOOGLE_TRANSLATE_API_KEY` – Google Translate API key.
 - `CONFIG_PATH` – Path to the orchestrator configuration, defaults to `config/playbook.yaml`.
+- `API_AUTH_KEY` – Token required by the FastAPI server for requests.

--- a/src/api.py
+++ b/src/api.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+"""HTTP interface exposing :class:`SolutionOrchestrator` via FastAPI."""
+
+from typing import Any, Dict
+import os
+
+from fastapi import Depends, FastAPI, Header, HTTPException
+from pydantic import BaseModel
+
+
+class Event(BaseModel):
+    """Schema for incoming events."""
+
+    type: str
+    payload: Dict[str, Any] = {}
+
+from .solution_orchestrator import SolutionOrchestrator
+from .config import settings
+
+
+def create_app(orchestrator: SolutionOrchestrator | None = None) -> FastAPI:
+    """Return a configured :class:`FastAPI` app bound to ``orchestrator``.
+
+    Parameters
+    ----------
+    orchestrator:
+        Instance of :class:`SolutionOrchestrator` to dispatch requests to. If
+        omitted an orchestrator with no teams is created.
+    """
+
+    app = FastAPI(title="Brookside API", description="SolutionOrchestrator HTTP interface")
+    orch = orchestrator or SolutionOrchestrator({})
+
+    async def _auth(x_api_key: str = Header(...)) -> None:
+        required = settings.API_AUTH_KEY
+        if required and x_api_key != required:
+            raise HTTPException(status_code=401, detail="invalid api key")
+
+    @app.post("/teams/{name}/event")
+    async def handle_event(name: str, event: Event, _=Depends(_auth)) -> Dict[str, Any]:
+        """Dispatch ``event`` to ``name`` via the orchestrator."""
+        result = await orch.handle_event(name, event.dict())
+        if result.get("status") == "unknown_team":
+            raise HTTPException(status_code=404, detail="unknown team")
+        orch.report_status(name, "handled")
+        return result
+
+    @app.get("/teams/{name}/status")
+    def get_status(name: str, _=Depends(_auth)) -> Dict[str, Any]:
+        """Return the last reported status for ``name``."""
+        status = orch.get_status(name)
+        if status is None:
+            raise HTTPException(status_code=404, detail="unknown team")
+        return {"team": name, "status": status}
+
+    return app
+
+
+app = create_app()
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    import sys
+    import uvicorn
+
+    def _parse_team_mapping(pairs: list[str]) -> dict[str, str]:
+        mapping: dict[str, str] = {}
+        for pair in pairs:
+            if "=" not in pair:
+                raise SystemExit(f"Invalid team spec '{pair}'. Use NAME=PATH")
+            name, path = pair.split("=", 1)
+            mapping[name] = path
+        return mapping
+
+    teams = _parse_team_mapping(sys.argv[1:])
+    orch = SolutionOrchestrator(teams)
+    app = create_app(orch)
+
+    port = int(os.getenv("PORT", "8000"))
+    uvicorn.run(app, host="0.0.0.0", port=port)

--- a/src/config.py
+++ b/src/config.py
@@ -164,6 +164,7 @@ class Settings(BaseSettings):
     # Utility Services
     GOOGLE_TRANSLATE_API_KEY: Optional[str] = None
     CONFIG_PATH: str = "config/playbook.yaml"
+    API_AUTH_KEY: Optional[str] = None
 
     # Memory Service
     MEMORY_BACKEND: Literal["rest", "file"] = "rest"

--- a/src/constants.py
+++ b/src/constants.py
@@ -116,6 +116,7 @@ PLAID_ENVIRONMENT = settings.PLAID_ENVIRONMENT
 # Utility Services
 GOOGLE_TRANSLATE_API_KEY = settings.GOOGLE_TRANSLATE_API_KEY
 CONFIG_PATH = settings.CONFIG_PATH
+API_AUTH_KEY = settings.API_AUTH_KEY
 
 # Logistics & e-commerce APIs
 TMS_API_URL = settings.TMS_API_URL

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import json
+import os
+import socket
+import threading
+import sys
+import time
+import types
+from pathlib import Path
+
+from urllib import request as urllib_request
+
+from src.solution_orchestrator import SolutionOrchestrator
+from src import api
+
+def _http_get(url: str, headers: dict[str, str] | None = None) -> tuple[int, str]:
+    req = urllib_request.Request(url, headers=headers or {})
+    try:
+        with urllib_request.urlopen(req) as resp:  # noqa: S310 -- in tests
+            return resp.getcode(), resp.read().decode()
+    except urllib_request.HTTPError as err:  # type: ignore[attr-defined]
+        return err.code, err.read().decode()
+
+
+def _http_post(url: str, data: dict, headers: dict[str, str] | None = None) -> tuple[int, str]:
+    payload = json.dumps(data).encode()
+    req = urllib_request.Request(url, data=payload, headers=headers or {}, method="POST")
+    req.add_header("Content-Type", "application/json")
+    try:
+        with urllib_request.urlopen(req) as resp:  # noqa: S310 -- in tests
+            return resp.getcode(), resp.read().decode()
+    except urllib_request.HTTPError as err:  # type: ignore[attr-defined]
+        return err.code, err.read().decode()
+
+from src.agents.base_agent import BaseAgent
+
+
+class EchoAgent(BaseAgent):
+    def run(self, payload):
+        return {"echo": payload}
+
+
+def _write_team(tmp_path: Path) -> Path:
+    cfg = {"config": {"participants": [{"config": {"name": "echo_agent"}}]}}
+    path = tmp_path / "team.json"
+    path.write_text(json.dumps(cfg))
+    return path
+
+
+def _register_agent():
+    mod = types.ModuleType("src.agents.echo_agent")
+    mod.EchoAgent = EchoAgent
+    sys.modules["src.agents.echo_agent"] = mod
+
+
+def _get_free_port() -> int:
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return port
+
+
+def _start_server(app, port: int):
+    import uvicorn
+
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error")
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    for _ in range(100):
+        try:
+            _http_get(f"http://127.0.0.1:{port}/docs")
+            return server, thread
+        except Exception:
+            time.sleep(0.1)
+    server.should_exit = True
+    thread.join(timeout=5)
+    raise RuntimeError("server failed to start")
+
+
+def test_event_and_status(tmp_path):
+    _register_agent()
+    team_cfg = _write_team(tmp_path)
+    port = _get_free_port()
+    orch = SolutionOrchestrator({"demo": str(team_cfg)})
+    api.settings.API_AUTH_KEY = "secret"
+    app = api.create_app(orch)
+    server, thread = _start_server(app, port)
+
+    try:
+        code, body = _http_post(
+            f"http://127.0.0.1:{port}/teams/demo/event",
+            {"type": "echo_agent", "payload": {"foo": 1}},
+            headers={"X-API-Key": "secret"},
+        )
+        assert code == 200
+        assert json.loads(body)["result"]["echo"]["foo"] == 1
+
+        code, body = _http_get(
+            f"http://127.0.0.1:{port}/teams/demo/status",
+            headers={"X-API-Key": "secret"},
+        )
+        assert code == 200
+        assert json.loads(body)["status"] == "handled"
+    finally:
+        server.should_exit = True
+        thread.join(timeout=5)
+
+
+def test_auth_failure(tmp_path):
+    _register_agent()
+    team_cfg = _write_team(tmp_path)
+    port = _get_free_port()
+    orch = SolutionOrchestrator({"demo": str(team_cfg)})
+    api.settings.API_AUTH_KEY = "secret"
+    app = api.create_app(orch)
+    server, thread = _start_server(app, port)
+
+    try:
+        code, _ = _http_post(
+            f"http://127.0.0.1:{port}/teams/demo/event",
+            {},
+            headers={"X-API-Key": "bad"},
+        )
+        assert code == 401
+    finally:
+        server.should_exit = True
+        thread.join(timeout=5)
+
+
+def test_unknown_team(tmp_path):
+    port = _get_free_port()
+    app = api.create_app(SolutionOrchestrator({}))
+    api.settings.API_AUTH_KEY = "secret"
+    server, thread = _start_server(app, port)
+
+    try:
+        code, _ = _http_post(
+            f"http://127.0.0.1:{port}/teams/missing/event",
+            {"type": "x"},
+            headers={"X-API-Key": "secret"},
+        )
+        assert code == 404
+    finally:
+        server.should_exit = True
+        thread.join(timeout=5)


### PR DESCRIPTION
## Summary
- add FastAPI server in `src/api.py`
- expose `/teams/{name}/event` and `/teams/{name}/status` endpoints
- stub API key authentication via `API_AUTH_KEY`
- document `API_AUTH_KEY` and new HTTP API usage
- implement tests covering the new API

## Testing
- `pytest -q`

------
