### PR TITLE
Add role-based agents with tool permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ A trimmed example from `sales_team_full.json` looks like:
   "provider": "autogen_agentchat.teams.RoundRobinGroupChat",
   "config": {
     "participants": [
-      {"provider": "autogen_agentchat.agents.AssistantAgent", "config": {"name": "orchestrator_agent"}},
-      {"provider": "autogen_agentchat.agents.AssistantAgent", "config": {"name": "lead_agent"}}
+      {"provider": "src.agents.roles.AssistantAgent", "config": {"name": "orchestrator_agent"}},
+      {"provider": "src.agents.roles.AssistantAgent", "config": {"name": "lead_agent"}}
     ],
     "tools": [
       {"provider": "src.tools.crm_tool.CRMTool"}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -94,7 +94,7 @@ If ``config_path`` is not provided, a built-in default mapping identical to the 
 1. Reads the team configuration file.
 2. For each participant entry, dynamically imports the agent class using
    `importlib.import_module(f"src.agents.{name}")`.
-3. Builds the AutoGen agents (e.g. `autogen_agentchat.agents.AssistantAgent`) and registers them on an internal `EventBus`.
+3. Builds the AutoGen agents (e.g. `src.agents.roles.AssistantAgent`) and registers them on an internal `EventBus`.
 
 All AutoGen import statements therefore execute when the team orchestrator is constructed.  The modules remain loaded for the lifetime of the orchestrator.
 
@@ -116,7 +116,7 @@ At this point all AutoGen agents are live and waiting for events. Teams remain a
 
 ## AutoGen Agents and Providers
 
-Team JSON files under `src/teams/` describe `RoundRobinGroupChat` configurations.  Each agent entry specifies a `provider` such as `autogen_agentchat.agents.AssistantAgent` or `autogen_ext.models.openai.OpenAIChatCompletionClient`.  When a team is loaded, these providers are instantiated and stitched together by AutoGen.
+Team JSON files under `src/teams/` describe `RoundRobinGroupChat` configurations.  Each agent entry specifies a `provider` such as `src.agents.roles.AssistantAgent` or `autogen_ext.models.openai.OpenAIChatCompletionClient`.  When a team is loaded, these providers are instantiated and stitched together by AutoGen.
 
 OpenAI powered components (via `OpenAIChatCompletionClient`) are created using API keys provided by `src.config.settings`.  The settings object reads values from environment variables and the relevant `.env` file.  Whenever an AutoGen agent needs a model response, the provider invokes the OpenAI API to generate the next message.
 

--- a/src/agents/roles/__init__.py
+++ b/src/agents/roles/__init__.py
@@ -1,0 +1,70 @@
+"""Role-based base agents with tool permission sets."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from ..base_agent import BaseAgent
+from ...utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class RoleAgent(BaseAgent):
+    """Base class enforcing allowed tool permissions."""
+
+    #: Unique role identifier used for logging
+    role_name: str = "role"
+    #: List of tool names permitted for this role
+    allowed_tools: List[str] = []
+
+    def __init__(self, allowed_tools: Iterable[str] | None = None) -> None:
+        if allowed_tools is not None:
+            self.allowed_tools = list(allowed_tools)
+
+    def can_use(self, tool_name: str) -> bool:
+        """Return ``True`` if ``tool_name`` is permitted."""
+        return tool_name in self.allowed_tools
+
+    def run(self, payload: dict) -> dict:
+        """Validate tool usage in ``payload`` and echo status."""
+        tool = payload.get("tool")
+        if tool and not self.can_use(tool):
+            logger.warning("%s attempted disallowed tool %s", self.role_name, tool)
+            return {"error": "permission_denied", "tool": tool}
+        logger.info("%s processed payload", self.role_name)
+        return {"status": "ok"}
+
+
+class AssistantAgent(RoleAgent):
+    """General assistant role with broad permissions."""
+
+    role_name = "assistant"
+    allowed_tools = [
+        "chat_tool",
+        "email_tool",
+        "memory_tools",
+        "notification_tools",
+    ]
+
+
+class WriterAgent(RoleAgent):
+    """Content writer role with document-focused tools."""
+
+    role_name = "writer"
+    allowed_tools = [
+        "docgen_tool",
+        "email_tool",
+    ]
+
+
+class AnalystAgent(RoleAgent):
+    """Data analyst role permitted analytical utilities."""
+
+    role_name = "analyst"
+    allowed_tools = [
+        "metrics_tools",
+        "crm_tools",
+        "segmentation_tools",
+    ]
+

--- a/src/teams/ecommerce_team.json
+++ b/src/teams/ecommerce_team.json
@@ -8,7 +8,7 @@
   "config": {
     "participants": [
       {
-        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "provider": "src.agents.roles.AssistantAgent",
         "component_type": "agent",
         "version": 1,
         "component_version": 1,
@@ -17,7 +17,7 @@
         "config": {"name": "ecommerce_agent"}
       },
       {
-        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "provider": "src.agents.roles.AssistantAgent",
         "component_type": "agent",
         "version": 1,
         "component_version": 1,
@@ -26,7 +26,7 @@
         "config": {"name": "fulfillment_agent"}
       },
       {
-        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "provider": "src.agents.roles.AssistantAgent",
         "component_type": "agent",
         "version": 1,
         "component_version": 1,

--- a/src/teams/fulfillment_pipeline_team.json
+++ b/src/teams/fulfillment_pipeline_team.json
@@ -8,7 +8,7 @@
   "config": {
     "participants": [
       {
-        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "provider": "src.agents.roles.AssistantAgent",
         "component_type": "agent",
         "version": 1,
         "component_version": 1,
@@ -17,7 +17,7 @@
         "config": {"name": "fulfillment_agent"}
       },
       {
-        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "provider": "src.agents.roles.AssistantAgent",
         "component_type": "agent",
         "version": 1,
         "component_version": 1,
@@ -26,7 +26,7 @@
         "config": {"name": "inventory_management_agent"}
       },
       {
-        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "provider": "src.agents.roles.AssistantAgent",
         "component_type": "agent",
         "version": 1,
         "component_version": 1,
@@ -35,7 +35,7 @@
         "config": {"name": "tms_agent"}
       },
       {
-        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "provider": "src.agents.roles.AssistantAgent",
         "component_type": "agent",
         "version": 1,
         "component_version": 1,

--- a/src/teams/inventory_management_team.json
+++ b/src/teams/inventory_management_team.json
@@ -8,7 +8,7 @@
   "config": {
     "participants": [
       {
-        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "provider": "src.agents.roles.AssistantAgent",
         "component_type": "agent",
         "version": 1,
         "component_version": 1,
@@ -17,7 +17,7 @@
         "config": {"name": "inventory_management_agent"}
       },
       {
-        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "provider": "src.agents.roles.AssistantAgent",
         "component_type": "agent",
         "version": 1,
         "component_version": 1,

--- a/src/teams/on_the_road_team.json
+++ b/src/teams/on_the_road_team.json
@@ -8,7 +8,7 @@
   "config": {
     "participants": [
       {
-        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "provider": "src.agents.roles.AssistantAgent",
         "component_type": "agent",
         "version": 1,
         "component_version": 1,
@@ -17,7 +17,7 @@
         "config": {"name": "on_road_agent"}
       },
       {
-        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "provider": "src.agents.roles.AssistantAgent",
         "component_type": "agent",
         "version": 1,
         "component_version": 1,

--- a/src/teams/operations_team.json
+++ b/src/teams/operations_team.json
@@ -8,7 +8,7 @@
   "config": {
     "participants": [
       {
-        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "provider": "src.agents.roles.AssistantAgent",
         "component_type": "agent",
         "version": 1,
         "component_version": 1,
@@ -17,7 +17,7 @@
         "config": {"name": "inbound_agent"}
       },
       {
-        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "provider": "src.agents.roles.AssistantAgent",
         "component_type": "agent",
         "version": 1,
         "component_version": 1,
@@ -26,7 +26,7 @@
         "config": {"name": "outbound_agent"}
       },
       {
-        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "provider": "src.agents.roles.AssistantAgent",
         "component_type": "agent",
         "version": 1,
         "component_version": 1,
@@ -35,7 +35,7 @@
         "config": {"name": "inventory_management_agent"}
       },
       {
-        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "provider": "src.agents.roles.AssistantAgent",
         "component_type": "agent",
         "version": 1,
         "component_version": 1,
@@ -44,7 +44,7 @@
         "config": {"name": "tms_agent"}
       },
       {
-        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "provider": "src.agents.roles.AssistantAgent",
         "component_type": "agent",
         "version": 1,
         "component_version": 1,

--- a/src/teams/real_estate_team.json
+++ b/src/teams/real_estate_team.json
@@ -8,7 +8,7 @@
   "config": {
     "participants": [
       {
-        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "provider": "src.agents.roles.AssistantAgent",
         "component_type": "agent",
         "version": 1,
         "component_version": 1,
@@ -17,7 +17,7 @@
         "config": {"name": "real_estate_lead_agent"}
       },
       {
-        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "provider": "src.agents.roles.AssistantAgent",
         "component_type": "agent",
         "version": 1,
         "component_version": 1,
@@ -26,7 +26,7 @@
         "config": {"name": "mls_agent"}
       },
       {
-        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "provider": "src.agents.roles.WriterAgent",
         "component_type": "agent",
         "version": 1,
         "component_version": 1,
@@ -35,7 +35,7 @@
         "config": {"name": "listing_agent"}
       },
       {
-        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "provider": "src.agents.roles.WriterAgent",
         "component_type": "agent",
         "version": 1,
         "component_version": 1,

--- a/src/teams/sales_team_full.json
+++ b/src/teams/sales_team_full.json
@@ -8,7 +8,7 @@
   "config": {
     "participants": [
       {
-        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "provider": "src.agents.roles.AssistantAgent",
         "component_type": "agent",
         "version": 1,
         "component_version": 1,
@@ -103,7 +103,7 @@
         }
       },
       {
-        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "provider": "src.agents.roles.AssistantAgent",
         "component_type": "agent",
         "version": 1,
         "component_version": 1,
@@ -168,7 +168,7 @@
         }
       },
       {
-        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "provider": "src.agents.roles.AssistantAgent",
         "component_type": "agent",
         "version": 1,
         "component_version": 1,
@@ -233,7 +233,7 @@
         }
       },
       {
-        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "provider": "src.agents.roles.AssistantAgent",
         "component_type": "agent",
         "version": 1,
         "component_version": 1,
@@ -298,7 +298,7 @@
         }
       },
       {
-        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "provider": "src.agents.roles.AssistantAgent",
         "component_type": "agent",
         "version": 1,
         "component_version": 1,
@@ -363,7 +363,7 @@
         }
       },
       {
-        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "provider": "src.agents.roles.AssistantAgent",
         "component_type": "agent",
         "version": 1,
         "component_version": 1,
@@ -428,7 +428,7 @@
         }
       },
       {
-        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "provider": "src.agents.roles.AssistantAgent",
         "component_type": "agent",
         "version": 1,
         "component_version": 1,
@@ -493,7 +493,7 @@
         }
       },
       {
-        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "provider": "src.agents.roles.AssistantAgent",
         "component_type": "agent",
         "version": 1,
         "component_version": 1,
@@ -558,7 +558,7 @@
         }
       },
       {
-        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "provider": "src.agents.roles.AssistantAgent",
         "component_type": "agent",
         "version": 1,
         "component_version": 1,
@@ -623,7 +623,7 @@
         }
       },
       {
-        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "provider": "src.agents.roles.AssistantAgent",
         "component_type": "agent",
         "version": 1,
         "component_version": 1,
@@ -688,7 +688,7 @@
         }
       },
       {
-        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "provider": "src.agents.roles.AssistantAgent",
         "component_type": "agent",
         "version": 1,
         "component_version": 1,
@@ -753,7 +753,7 @@
         }
       },
       {
-        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "provider": "src.agents.roles.AssistantAgent",
         "component_type": "agent",
         "version": 1,
         "component_version": 1,
@@ -818,7 +818,7 @@
         }
       },
       {
-        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "provider": "src.agents.roles.AssistantAgent",
         "component_type": "agent",
         "version": 1,
         "component_version": 1,
@@ -883,7 +883,7 @@
         }
       },
       {
-        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "provider": "src.agents.roles.AssistantAgent",
         "component_type": "agent",
         "version": 1,
         "component_version": 1,
@@ -948,7 +948,7 @@
         }
       },
       {
-        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "provider": "src.agents.roles.AssistantAgent",
         "component_type": "agent",
         "version": 1,
         "component_version": 1,
@@ -1013,7 +1013,7 @@
         }
       },
       {
-        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "provider": "src.agents.roles.AssistantAgent",
         "component_type": "agent",
         "version": 1,
         "component_version": 1,
@@ -1078,7 +1078,7 @@
         }
       },
       {
-        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "provider": "src.agents.roles.AssistantAgent",
         "component_type": "agent",
         "version": 1,
         "component_version": 1,
@@ -1143,7 +1143,7 @@
         }
       }
       {
-        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "provider": "src.agents.roles.AnalystAgent",
         "component_type": "agent",
         "version": 1,
         "component_version": 1,

--- a/tests/test_role_agents.py
+++ b/tests/test_role_agents.py
@@ -1,0 +1,22 @@
+from src.agents.roles import AssistantAgent, WriterAgent, AnalystAgent
+
+
+def test_assistant_permissions():
+    agent = AssistantAgent()
+    assert agent.can_use("chat_tool")
+    assert agent.run({"tool": "chat_tool"}) == {"status": "ok"}
+    denied = agent.run({"tool": "unknown_tool"})
+    assert denied["error"] == "permission_denied"
+
+
+def test_writer_permissions():
+    agent = WriterAgent()
+    assert agent.can_use("docgen_tool")
+    assert not agent.can_use("crm_tool")
+
+
+def test_analyst_permissions():
+    agent = AnalystAgent()
+    assert agent.can_use("metrics_tools")
+    assert agent.run({"tool": "metrics_tools"}) == {"status": "ok"}
+


### PR DESCRIPTION
## Summary
- implement `WriterAgent`, `AnalystAgent` and `AssistantAgent` roles
- document new roles and update architecture docs
- use the new roles across all team JSON files
- add tests for role agent permissions

## Testing
- `pytest -q`

------
