### PR TITLE
Add skill-based agent delegation

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,13 @@ orch.handle_event("sales", {"type": "lead_capture", "payload": {}})
 
 Teams can report progress upward via `orch.report_status(team, status)`.
 
+Agents may also advertise a list of `skills`. The orchestrator can route a task
+to the first agent declaring the requested skill:
+
+```python
+orch.delegate_by_skill_sync("copywriting", {"text": "draft this"})
+```
+
 ### 🖥️ Command Line Usage
 
 The project exposes a small CLI for running and interacting with the

--- a/docs/components.md
+++ b/docs/components.md
@@ -21,7 +21,7 @@ The implementation can be swapped at runtime so your agents can persist data to 
 
 ## Agents
 
-Agents live under `src/agents/` and are simple Python classes with a `run()` method. Many derive from a small `BaseAgent` helper that handles event subscription. Examples include:
+Agents live under `src/agents/` and are simple Python classes with a `run()` method. Many derive from a small `BaseAgent` helper that handles event subscription. Each agent can optionally declare a list of `skills` describing its capabilities. Examples include:
 
 * `ChatbotAgent` – responds to user queries.
 * `LeadCaptureAgent` – parses forms and enters prospects into the CRM.

--- a/src/agents/base_agent.py
+++ b/src/agents/base_agent.py
@@ -1,11 +1,15 @@
 """Common abstract base class for all agents used in the examples."""
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 
 class BaseAgent(ABC):
     """Define the minimal interface required by the orchestrator."""
+
+    #: Optional list of capabilities advertised by the agent.  Orchestrators may
+    #: use these to dynamically select an agent for a given task.
+    skills: List[str] = []
 
     @abstractmethod
     def run(self, payload: Dict[str, Any]) -> Any:

--- a/tests/test_skill_lookup.py
+++ b/tests/test_skill_lookup.py
@@ -1,0 +1,68 @@
+import json
+import sys
+import types
+from pathlib import Path
+
+from src.team_orchestrator import TeamOrchestrator
+from src.agents.base_agent import BaseAgent
+
+
+class FooAgent(BaseAgent):
+    skills = ["foo", "common"]
+
+    def run(self, payload):
+        return {"agent": "foo", **payload}
+
+
+class BarAgent(BaseAgent):
+    skills = ["bar", "common"]
+
+    def run(self, payload):
+        return {"agent": "bar", **payload}
+
+
+def _write_team(tmp_path: Path) -> Path:
+    cfg = {
+        "config": {
+            "participants": [
+                {"config": {"name": "foo_agent"}},
+                {"config": {"name": "bar_agent"}},
+            ]
+        }
+    }
+    path = tmp_path / "team.json"
+    path.write_text(json.dumps(cfg))
+    return path
+
+
+def test_delegate_by_skill(tmp_path):
+    team_cfg = _write_team(tmp_path)
+    mod1 = types.ModuleType("src.agents.foo_agent")
+    mod1.FooAgent = FooAgent
+    sys.modules["src.agents.foo_agent"] = mod1
+    mod2 = types.ModuleType("src.agents.bar_agent")
+    mod2.BarAgent = BarAgent
+    sys.modules["src.agents.bar_agent"] = mod2
+
+    orch = TeamOrchestrator(str(team_cfg))
+
+    res = orch.delegate_by_skill_sync("bar", {"val": 1})
+    assert res["result"]["agent"] == "bar"
+
+    res2 = orch.delegate_by_skill_sync("foo", {"val": 2})
+    assert res2["result"]["agent"] == "foo"
+
+
+def test_delegate_unknown_skill(tmp_path):
+    team_cfg = _write_team(tmp_path)
+    mod = types.ModuleType("src.agents.foo_agent")
+    mod.FooAgent = FooAgent
+    sys.modules["src.agents.foo_agent"] = mod
+    mod2 = types.ModuleType("src.agents.bar_agent")
+    mod2.BarAgent = BarAgent
+    sys.modules["src.agents.bar_agent"] = mod2
+
+    orch = TeamOrchestrator(str(team_cfg))
+
+    res = orch.delegate_by_skill_sync("missing", {"v": 3})
+    assert res["status"] == "unhandled"


### PR DESCRIPTION
## Summary
- add `skills` attribute to BaseAgent
- add skill lookup and delegation in BaseOrchestrator
- document new feature in README and component guide
- test dynamic agent selection by skill

## Testing
- `pytest -q`

------
