### PR TITLE
Add ReviewAgent with draft approval workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ also included:
 * `debugger_agent.py` – listen for `*.Error` events and propose patches.
 * `qa_agent.py` – run scripted conversations against `SupportAgent` and emit QA
   reports.
+* `review_agent.py` – automatically approve or reject drafts published on the event bus.
 
 These helper scripts keep network calls behind feature flags so they remain
 test-safe by default.

--- a/docs/agents_overview.md
+++ b/docs/agents_overview.md
@@ -42,6 +42,7 @@ This page lists all of the built-in agents available in the Brookside BI framewo
 * **ProcurementAgent** (`src/agents/operations/procurement_agent.py`) – Agent for automating material purchasing decisions.
 * **SupportAgent** (`src/agents/operations/support_agent.py`) – Autonomous Customer Support agent.
 * **RevOpsAgent** (`src/agents/sales/revops_agent.py`) – Revenue operations agent producing pipeline forecasts.
+* **ReviewAgent** (`src/agents/review_agent.py`) – Validates drafts and publishes approval results.
 
 ## Key Utilities
 

--- a/src/agents/review_agent.py
+++ b/src/agents/review_agent.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+"""Lightweight agent for reviewing text drafts.
+
+The ``ReviewAgent`` checks a draft for banned terms and either approves it or
+returns feedback comments. It can optionally subscribe to an
+:class:`agentic_core.EventBus` to automatically review drafts published on the
+``draft.created`` topic.
+"""
+
+from typing import Iterable, List
+
+from agentic_core import EventBus
+
+from .base_agent import BaseAgent
+
+
+class ReviewAgent(BaseAgent):
+    """Simple reviewer that approves or rejects drafts.
+
+    Parameters
+    ----------
+    bus:
+        Event bus used for communication. When provided, the agent subscribes to
+        the ``draft.created`` topic and publishes results to ``draft.reviewed``.
+    banned_words:
+        Optional iterable of words that should trigger a rejection.
+    """
+
+    def __init__(
+        self,
+        bus: EventBus | None = None,
+        banned_words: Iterable[str] | None = None,
+    ) -> None:
+        self.bus = bus
+        self.banned_words = {w.lower() for w in (banned_words or {"fixme", "bad"})}
+        if self.bus:
+            self.bus.subscribe("draft.created", self._on_draft)
+
+    def _on_draft(self, payload: dict) -> None:
+        """EventBus callback for incoming drafts."""
+        result = self.run(payload)
+        if self.bus:
+            self.bus.publish("draft.reviewed", result)
+
+    def run(self, payload: dict) -> dict:
+        """Examine a draft and return an approval decision."""
+        draft = str(payload.get("draft", ""))
+        comments: List[str] = []
+        for word in self.banned_words:
+            if word in draft.lower():
+                comments.append(f"Remove forbidden term '{word}'.")
+
+        status = "rejected" if comments else "approved"
+        result = {"status": status}
+        if comments:
+            result["comments"] = comments
+        return result

--- a/tests/test_review_agent.py
+++ b/tests/test_review_agent.py
@@ -1,0 +1,40 @@
+from agentic_core import EventBus
+from src.agents.review_agent import ReviewAgent
+from src.agents.base_agent import BaseAgent
+
+
+class DraftAgent(BaseAgent):
+    """Minimal author agent used in tests."""
+
+    def __init__(self, bus: EventBus):
+        self.bus = bus
+
+    def run(self, payload):
+        draft = payload.get("text", "")
+        self.bus.publish("draft.created", {"draft": draft})
+        return {"status": "submitted", "draft": draft}
+
+
+def test_review_agent_approves():
+    bus = EventBus()
+    reviews = []
+    bus.subscribe("draft.reviewed", reviews.append)
+
+    review_agent = ReviewAgent(bus)
+    author = DraftAgent(bus)
+
+    author.run({"text": "All good here"})
+    assert reviews[0]["status"] == "approved"
+
+
+def test_review_agent_rejects():
+    bus = EventBus()
+    reviews = []
+    bus.subscribe("draft.reviewed", reviews.append)
+
+    review_agent = ReviewAgent(bus, banned_words={"bad"})
+    author = DraftAgent(bus)
+
+    author.run({"text": "This is a bad idea"})
+    assert reviews[0]["status"] == "rejected"
+    assert "bad" in reviews[0]["comments"][0].lower()


### PR DESCRIPTION
## Summary
- add ReviewAgent for approving or rejecting drafted text
- document ReviewAgent in README and agent catalog
- test collaboration between a DraftAgent and ReviewAgent

## Testing
- `pytest -q`

------
