### PR TITLE
Add PlannerAgent and orchestration flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,26 @@ to the first agent declaring the requested skill:
 orch.delegate_by_skill_sync("copywriting", {"text": "draft this"})
 ```
 
+#### Planner Agent
+
+For fully automated flows a `PlannerAgent` can be attached to the
+`SolutionOrchestrator`. Provide a mapping of goals to task sequences when
+constructing the orchestrator:
+
+```python
+plans = {
+    "demo": [
+        {"team": "sales", "event": {"type": "lead_capture", "payload": {"email": "a@example.com"}}},
+        {"team": "sales", "event": {"type": "crm_pipeline", "payload": {"deal_id": "d1", "calendar_id": "c", "followup_template": {}}}},
+    ]
+}
+orch = SolutionOrchestrator({"sales": "src/teams/sales_team_full.json"}, planner_plans=plans)
+orch.execute_goal("demo")
+```
+
+The planner dispatches each event to the appropriate team in order and returns
+their combined results.
+
 ### 🖥️ Command Line Usage
 
 The project exposes a small CLI for running and interacting with the

--- a/docs/agents_overview.md
+++ b/docs/agents_overview.md
@@ -43,6 +43,7 @@ This page lists all of the built-in agents available in the Brookside BI framewo
 * **SupportAgent** (`src/agents/operations/support_agent.py`) – Autonomous Customer Support agent.
 * **RevOpsAgent** (`src/agents/sales/revops_agent.py`) – Revenue operations agent producing pipeline forecasts.
 * **ReviewAgent** (`src/agents/review_agent.py`) – Validates drafts and publishes approval results.
+* **PlannerAgent** (`src/agents/planner_agent.py`) – Executes goal-based plans by sequencing events across teams.
 
 ## Key Utilities
 

--- a/src/agents/planner_agent.py
+++ b/src/agents/planner_agent.py
@@ -1,0 +1,57 @@
+"""Agent responsible for executing goal-based task plans."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, TYPE_CHECKING
+
+from .base_agent import BaseAgent
+from ..utils.logger import get_logger
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..solution_orchestrator import SolutionOrchestrator
+
+logger = get_logger(__name__)
+
+
+class PlannerAgent(BaseAgent):
+    """Sequence events across teams to accomplish high level goals.
+
+    Parameters
+    ----------
+    orchestrator:
+        :class:`~src.solution_orchestrator.SolutionOrchestrator` used to dispatch
+        events.
+    plans:
+        Mapping of goal names to ordered lists of tasks. Each task must include a
+        ``team`` key identifying the target team and an ``event`` dictionary
+        compatible with :meth:`SolutionOrchestrator.handle_event_sync`.
+    """
+
+    def __init__(
+        self,
+        orchestrator: SolutionOrchestrator,
+        plans: Dict[str, List[Dict[str, Any]]],
+    ) -> None:
+        self.orchestrator = orchestrator
+        self.plans = plans
+
+    def run(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Execute the task sequence for ``payload['goal']``.
+
+        Returns a dictionary with the results of each task. If the goal is not
+        known ``{"status": "unknown_goal"}`` is returned.
+        """
+        goal = str(payload.get("goal", ""))
+        tasks = self.plans.get(goal)
+        if not tasks:
+            logger.warning("Planner received unknown goal '%s'", goal)
+            return {"status": "unknown_goal"}
+
+        results = []
+        for idx, task in enumerate(tasks):
+            team = task.get("team")
+            event = task.get("event", {})
+            logger.info("Planner executing step %s for team %s", idx + 1, team)
+            res = self.orchestrator.handle_event_sync(team, event)
+            results.append({"team": team, "result": res})
+        return {"status": "complete", "results": results}

--- a/tests/test_planner_agent.py
+++ b/tests/test_planner_agent.py
@@ -1,0 +1,68 @@
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from src.solution_orchestrator import SolutionOrchestrator
+from src.agents.base_agent import BaseAgent
+
+
+class DummyAgentA(BaseAgent):
+    def run(self, payload):
+        return {"handled_by": "A", **payload}
+
+
+class DummyAgentB(BaseAgent):
+    def run(self, payload):
+        return {"handled_by": "B", **payload}
+
+
+def _write_team(tmp_path: Path, agent_name: str) -> Path:
+    cfg = {
+        "responsibilities": [agent_name],
+        "config": {"participants": [{"config": {"name": agent_name}}]},
+    }
+    path = tmp_path / f"{agent_name}.json"
+    path.write_text(json.dumps(cfg))
+    return path
+
+
+def _register_agents():
+    mod_a = types.ModuleType("src.agents.dummy_agent_a")
+    mod_a.DummyAgentA = DummyAgentA
+    sys.modules["src.agents.dummy_agent_a"] = mod_a
+
+    mod_b = types.ModuleType("src.agents.dummy_agent_b")
+    mod_b.DummyAgentB = DummyAgentB
+    sys.modules["src.agents.dummy_agent_b"] = mod_b
+
+
+def test_execute_goal(tmp_path):
+    _register_agents()
+    team_a = _write_team(tmp_path, "dummy_agent_a")
+    team_b = _write_team(tmp_path, "dummy_agent_b")
+
+    plans = {
+        "demo": [
+            {"team": "A", "event": {"type": "dummy_agent_a", "payload": {"foo": 1}}},
+            {"team": "B", "event": {"type": "dummy_agent_b", "payload": {"bar": 2}}},
+        ]
+    }
+
+    orch = SolutionOrchestrator({"A": str(team_a), "B": str(team_b)}, planner_plans=plans)
+
+    result = orch.execute_goal("demo")
+    assert result["status"] == "complete"
+    assert result["results"][0]["result"]["result"]["handled_by"] == "A"
+    assert result["results"][1]["result"]["result"]["handled_by"] == "B"
+
+
+def test_missing_goal(tmp_path):
+    _register_agents()
+    team_a = _write_team(tmp_path, "dummy_agent_a")
+    orch = SolutionOrchestrator({"A": str(team_a)}, planner_plans={})
+
+    result = orch.execute_goal("missing")
+    assert result["status"] == "unknown_goal"


### PR DESCRIPTION
## Summary
- implement `PlannerAgent` that sequences tasks for a goal
- integrate the planner with `SolutionOrchestrator`
- document planner usage in README and agent catalog
- add unit tests for the planner

## Testing
- `pytest -q`

------
