### PR TITLE
Add Redis memory backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,8 @@ dotenv file before running the orchestrator or tests.
 | `CRM_API_URL` / `CRM_API_KEY` | Endpoint and key for your CRM integration |
 | `SENDGRID_API_KEY` | Sending transactional email |
 | `REDIS_URL` | Backend store for caching and message passing |
+| `MEMORY_BACKEND` | Selects memory service (`rest`, `file`, `redis`) |
+| `MEMORY_REDIS_URL` | Redis connection when `MEMORY_BACKEND=redis` |
 | `SLACK_WEBHOOK_URL` | Post notifications to Slack channels |
 | `TEAMS_WEBHOOK_URL` | Microsoft Teams notifications |
 | `PROMETHEUS_PUSHGATEWAY` | Metrics aggregation endpoint |
@@ -261,6 +263,28 @@ The compose file starts two services:
 
 The orchestrator is automatically configured to talk to the memory service at
 `http://memory:8000`.
+
+To use Redis instead of the bundled FastAPI memory server, start a Redis
+container and point the orchestrator at it:
+
+```yaml
+version: '3.9'
+services:
+  orchestrator:
+    build: .
+    command: ["start", "sales=src/teams/sales_team_full.json"]
+    environment:
+      MEMORY_BACKEND: redis
+      MEMORY_REDIS_URL: redis://redis:6379/0
+    depends_on:
+      - redis
+  redis:
+    image: redis:7-alpine
+    volumes:
+      - redis-data:/data
+volumes:
+  redis-data:
+```
 
 ## 📊 RevOps & Tooling
 

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -69,6 +69,12 @@ variables documented below.
 - `KAFKA_BOOTSTRAP_SERVERS` – Kafka broker list.
 - `RABBITMQ_URL` – RabbitMQ connection string.
 
+## Memory Service
+- `MEMORY_BACKEND` – Choose the persistence layer (`rest`, `file`, `redis`).
+- `MEMORY_ENDPOINT` – URL for the REST backend when `MEMORY_BACKEND=rest`.
+- `MEMORY_FILE_PATH` – File path when `MEMORY_BACKEND=file`.
+- `MEMORY_REDIS_URL` – Redis URL when `MEMORY_BACKEND=redis`.
+
 ## Messaging & Notifications
 - `SENDGRID_API_KEY` – SendGrid API key.
 - `SLACK_WEBHOOK_URL` – Slack webhook for notifications.

--- a/docs/memory_service.md
+++ b/docs/memory_service.md
@@ -78,15 +78,17 @@ sequenceDiagram
 
 ## Swapping backends
 
-Two built-in backends are provided:
+Three built-in backends are provided:
 
 1. **REST** – the original implementation used for examples. Configure the
    endpoint via ``MEMORY_ENDPOINT``.
 2. **File** – persists events to a local JSONL file. Controlled with
    ``MEMORY_FILE_PATH``.
+3. **Redis** – stores events in lists within a Redis instance using
+   ``MEMORY_REDIS_URL``.
 
-Select the backend using the ``MEMORY_BACKEND`` environment variable (``rest``
-or ``file``). The orchestrator reads these settings via ``src.config.Settings``
+Select the backend using the ``MEMORY_BACKEND`` environment variable (``rest``,
+``file`` or ``redis``). The orchestrator reads these settings via ``src.config.Settings``
 so they can be placed in a ``.env`` file or exported in your shell.
 
 You can also provide your own implementation by subclassing

--- a/src/config.py
+++ b/src/config.py
@@ -167,9 +167,10 @@ class Settings(BaseSettings):
     API_AUTH_KEY: Optional[str] = None
 
     # Memory Service
-    MEMORY_BACKEND: Literal["rest", "file"] = "rest"
+    MEMORY_BACKEND: Literal["rest", "file", "redis"] = "rest"
     MEMORY_ENDPOINT: str = "http://localhost:8000"
     MEMORY_FILE_PATH: str = "memory.jsonl"
+    MEMORY_REDIS_URL: str = "redis://localhost:6379/0"
 
     # Logistics & E-commerce
     TMS_API_URL: Optional[str] = None

--- a/src/memory_service/__init__.py
+++ b/src/memory_service/__init__.py
@@ -3,5 +3,11 @@
 from .base import BaseMemoryService
 from .rest import RestMemoryService
 from .file import FileMemoryService
+from .redis import RedisMemoryService
 
-__all__ = ["BaseMemoryService", "RestMemoryService", "FileMemoryService"]
+__all__ = [
+    "BaseMemoryService",
+    "RestMemoryService",
+    "FileMemoryService",
+    "RedisMemoryService",
+]

--- a/src/memory_service/redis.py
+++ b/src/memory_service/redis.py
@@ -1,0 +1,63 @@
+"""Redis based memory service implementation."""
+
+from __future__ import annotations
+
+import json
+import types
+from typing import Any, Dict, List
+
+from .base import BaseMemoryService
+from ..utils.logger import get_logger
+
+try:  # optional dependency
+    import redis  # type: ignore
+except Exception:  # pragma: no cover - fallback when redis is missing
+    redis = types.SimpleNamespace(
+        Redis=types.SimpleNamespace(
+            from_url=lambda *a, **k: types.SimpleNamespace(
+                rpush=lambda *a, **k: None,
+                lrange=lambda *a, **k: [],
+                ping=lambda *a, **k: True,
+            )
+        )
+    )
+
+logger = get_logger(__name__)
+
+
+class RedisMemoryService(BaseMemoryService):
+    """Persist events in a Redis list per key."""
+
+    def __init__(self, url: str) -> None:
+        self.client = redis.Redis.from_url(url, decode_responses=True)
+        try:  # pragma: no cover - network failure not relevant for unit tests
+            self.client.ping()
+        except Exception as exc:  # pragma: no cover - log only
+            logger.warning(f"Redis ping failed: {exc}")
+
+    def store(self, key: str, payload: Dict[str, Any]) -> bool:
+        try:
+            self.client.rpush(key, json.dumps(payload))
+            logger.info(f"Stored event for key={key} in Redis")
+            return True
+        except Exception as exc:  # pragma: no cover - runtime errors
+            logger.error(f"Redis store failed for key={key}: {exc}")
+            return False
+
+    def fetch(self, key: str, top_k: int = 5) -> List[Dict[str, Any]]:
+        try:
+            raw = self.client.lrange(key, -top_k, -1)
+        except Exception as exc:  # pragma: no cover - runtime errors
+            logger.error(f"Redis fetch failed for key={key}: {exc}")
+            return []
+
+        results: List[Dict[str, Any]] = []
+        for item in raw:
+            if isinstance(item, bytes):
+                item = item.decode("utf-8")
+            try:
+                results.append(json.loads(item))
+            except Exception:  # pragma: no cover - ignore malformed entries
+                continue
+        return results
+

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -35,6 +35,7 @@ from .agents.sales.crm_pipeline_agent import CRMPipelineAgent
 from .agents.sales.segmentation_ad_targeting_agent import SegmentationAdTargetingAgent
 from .memory_service import RestMemoryService
 from .memory_service.file import FileMemoryService
+from .memory_service.redis import RedisMemoryService
 from .memory_service.base import BaseMemoryService
 from .config import settings
 from .utils.logger import get_logger
@@ -115,6 +116,9 @@ class Orchestrator(BaseOrchestrator):
         if backend == "file":
             path = memory_file or settings.MEMORY_FILE_PATH
             memory: BaseMemoryService = FileMemoryService(path)
+        elif backend == "redis":
+            url = settings.MEMORY_REDIS_URL
+            memory = RedisMemoryService(url)
         else:
             endpoint = memory_endpoint or settings.MEMORY_ENDPOINT
             memory = RestMemoryService(endpoint)

--- a/tests/test_orchestrator_redis_backend.py
+++ b/tests/test_orchestrator_redis_backend.py
@@ -1,0 +1,52 @@
+import types
+import sys
+
+from src.orchestrator import Orchestrator
+from src.memory_service.redis import redis as redis_module
+
+class DummyRedis:
+    def __init__(self):
+        self.store = {}
+    def rpush(self, key, value):
+        self.store.setdefault(key, []).append(value)
+    def lrange(self, key, start, end):
+        data = self.store.get(key, [])
+        if start < 0:
+            start = len(data) + start
+        if end == -1:
+            end = None
+        else:
+            end += 1
+        return data[start:end]
+    def ping(self):
+        return True
+
+def test_orchestrator_redis_backend(monkeypatch):
+    class DummyScheduler:
+        def create_event(self, cid, ev):
+            return {"id": "evt"}
+
+    monkeypatch.setattr(
+        "src.tools.scheduler_tool.SchedulerTool",
+        lambda: DummyScheduler(),
+    )
+    sys.modules.setdefault(
+        "requests",
+        types.SimpleNamespace(
+            post=lambda *a, **k: types.SimpleNamespace(ok=True, json=lambda: {}),
+            get=lambda *a, **k: types.SimpleNamespace(ok=True, json=lambda: {}),
+        ),
+    )
+
+    client = DummyRedis()
+    monkeypatch.setattr(redis_module.Redis, 'from_url', lambda *a, **k: client)
+    monkeypatch.setenv('MEMORY_REDIS_URL', 'redis://localhost')
+
+    orch = Orchestrator(memory_backend="redis")
+
+    payload = {"form_data": {}, "source": "web"}
+    res = orch.handle_event_sync({"type": "lead_capture", "payload": payload})
+    assert res["status"] == "done"
+
+    assert len(client.store.get("lead_capture", [])) == 1
+

--- a/tests/test_redis_memory_service.py
+++ b/tests/test_redis_memory_service.py
@@ -1,0 +1,34 @@
+import types
+
+from src.memory_service.redis import RedisMemoryService, redis as redis_module
+
+class DummyRedis:
+    def __init__(self):
+        self.store = {}
+    def rpush(self, key, value):
+        self.store.setdefault(key, []).append(value)
+    def lrange(self, key, start, end):
+        data = self.store.get(key, [])
+        if start < 0:
+            start = len(data) + start
+        if end == -1:
+            end = None
+        else:
+            end += 1
+        return data[start:end]
+    def ping(self):
+        return True
+
+def test_store_and_fetch(monkeypatch):
+    client = DummyRedis()
+    monkeypatch.setattr(redis_module.Redis, 'from_url', lambda *a, **k: client)
+    svc = RedisMemoryService('redis://localhost')
+
+    assert svc.store('a', {'foo': 1})
+    assert svc.store('a', {'bar': 2})
+    assert svc.store('b', {'baz': 3})
+
+    assert svc.fetch('a') == [{'foo': 1}, {'bar': 2}]
+    assert svc.fetch('a', top_k=1) == [{'bar': 2}]
+    assert svc.fetch('missing') == []
+


### PR DESCRIPTION
## Summary
- implement `RedisMemoryService` as an optional backend
- allow Settings to pick between `rest`, `file` and `redis`
- update orchestrator to instantiate the correct backend
- document new options in README and docs
- add Docker Compose snippet for Redis usage
- add unit tests for Redis backend

## Testing
- `pytest -q`

------
