### PR TITLE
Add simple workflow engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,37 @@ memory services, agents, tools and the in-memory event bus with pointers on how
 to extend them.
 [docs/agents_overview.md](docs/agents_overview.md) contains a catalog of every built-in agent and the utility modules they rely on.
 
+## ⛓️ Workflow Engine
+
+This release introduces a lightweight workflow engine implemented as a simple
+state machine. Workflows are defined as an ordered list of steps in a JSON or
+YAML file. The engine loads the file, tracks the current step and exposes helper
+methods to advance through the chain.
+
+An example definition can be found at
+`src/workflows/examples/content_creation.json`:
+
+```json
+{
+  "name": "content_creation",
+  "steps": ["Research", "Draft", "Edit", "Send"]
+}
+```
+
+Load and execute the workflow:
+
+```python
+from src.workflows.engine import WorkflowEngine
+
+engine = WorkflowEngine.from_file("src/workflows/examples/content_creation.json")
+while not engine.is_complete():
+    print(f"Currently at: {engine.current}")
+    engine.advance()
+print(f"Finished on: {engine.current}")
+```
+
+See [docs/workflows.md](docs/workflows.md) for a detailed overview.
+
 ## 🤝 Contributing
 
 We welcome community contributions! Install the pre-commit hooks so your changes follow our formatting and style guidelines.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,0 +1,38 @@
+# Workflow Engine
+
+The workflow engine provides a tiny state machine for moving through a series of
+steps defined in JSON or YAML. Each workflow file contains a list of step names
+and an optional `name` field. The `WorkflowEngine` loads this definition and
+exposes methods to query the current step, advance to the next one and reset the
+flow.
+
+## Definition Format
+
+```json
+{
+  "name": "content_creation",
+  "steps": ["Research", "Draft", "Edit", "Send"]
+}
+```
+
+Save the file anywhere on disk and load it using
+`WorkflowEngine.from_file(path)`.
+
+## Basic Usage
+
+```python
+from src.workflows.engine import WorkflowEngine
+
+engine = WorkflowEngine.from_file("path/to/workflow.json")
+print(engine.current)  # -> first step
+engine.advance()       # move to next
+```
+
+`advance()` raises `StopIteration` once the workflow reaches the final step.
+Call `reset()` to start over.
+
+## Example
+
+The repository ships with a ready-made workflow at
+`src/workflows/examples/content_creation.json`. The unit tests demonstrate how to
+walk through the steps using the engine.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ openai>=1.0.0  # optional - used by ChatTool
 google-api-python-client>=2.0.0  # optional - for Google Calendar
 fastapi>=0.110.0  # memory service server
 uvicorn>=0.22.0
+PyYAML>=6.0
 

--- a/src/workflows/engine.py
+++ b/src/workflows/engine.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+"""Simple workflow engine implemented as a sequential state machine."""
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+try:
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - PyYAML is optional
+    yaml = None
+
+
+@dataclass
+class WorkflowDefinition:
+    """Representation of a workflow loaded from JSON or YAML."""
+
+    name: str
+    steps: List[str]
+
+
+class WorkflowEngine:
+    """State machine that walks through a series of steps."""
+
+    def __init__(self, definition: WorkflowDefinition) -> None:
+        if not definition.steps:
+            raise ValueError("Workflow must contain at least one step")
+        self.definition = definition
+        self._index = 0
+
+    @classmethod
+    def from_file(cls, path: str | Path) -> "WorkflowEngine":
+        """Load a workflow definition from a JSON or YAML file."""
+
+        path = Path(path)
+        text = path.read_text()
+        if path.suffix in {".yaml", ".yml"}:
+            if yaml is None:
+                raise ModuleNotFoundError(
+                    "PyYAML is required to load YAML workflow definitions"
+                )
+            data = yaml.safe_load(text)
+        else:
+            data = json.loads(text)
+        name = data.get("name", path.stem)
+        steps = data.get("steps")
+        if not isinstance(steps, list) or not all(isinstance(s, str) for s in steps):
+            raise ValueError(
+                "Invalid workflow definition: 'steps' must be a list of strings"
+            )
+        definition = WorkflowDefinition(name=name, steps=steps)
+        return cls(definition)
+
+    @property
+    def current(self) -> str:
+        """Return the current step name."""
+
+        return self.definition.steps[self._index]
+
+    def advance(self) -> str:
+        """Move to the next step and return its name."""
+
+        if self.is_complete():
+            raise StopIteration("Workflow already finished")
+        self._index += 1
+        return self.current
+
+    def reset(self) -> None:
+        """Restart the workflow from the first step."""
+
+        self._index = 0
+
+    def is_complete(self) -> bool:
+        """Return ``True`` if the workflow has reached the last step."""
+
+        return self._index >= len(self.definition.steps) - 1

--- a/src/workflows/examples/content_creation.json
+++ b/src/workflows/examples/content_creation.json
@@ -1,0 +1,4 @@
+{
+  "name": "content_creation",
+  "steps": ["Research", "Draft", "Edit", "Send"]
+}

--- a/tests/test_workflow_engine.py
+++ b/tests/test_workflow_engine.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+import pytest
+
+from src.workflows.engine import WorkflowEngine
+
+
+EXAMPLE = Path("src/workflows/examples/content_creation.json")
+
+
+def test_example_workflow_advances():
+    engine = WorkflowEngine.from_file(EXAMPLE)
+
+    assert engine.current == "Research"
+    assert not engine.is_complete()
+
+    assert engine.advance() == "Draft"
+    assert engine.advance() == "Edit"
+    assert engine.advance() == "Send"
+    assert engine.is_complete()
+
+    with pytest.raises(StopIteration):
+        engine.advance()
+
+    engine.reset()
+    assert engine.current == "Research"


### PR DESCRIPTION
## Summary
- introduce `WorkflowEngine` for sequential workflows
- add example workflow definition
- document workflow engine and update README
- include unit test for new workflow
- add PyYAML dependency for optional YAML support

## Testing
- `black src/workflows/engine.py tests/test_workflow_engine.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68543354a9c8832b8f7b8993d30775af