### PR TITLE
Implement activity logging with API access

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,19 @@ Fetch the latest status:
 curl -H "X-API-Key: mysecret" http://localhost:8000/teams/sales/status
 ```
 
+Query recent activity:
+
+```bash
+curl -H "X-API-Key: mysecret" http://localhost:8000/activity?limit=20
+```
+
+### 📈 Activity Logs
+
+Every handled event is appended to a JSON Lines file. Each entry records the
+handling agent, a short summary and a timestamp. The `GET /activity` endpoint
+returns the most recent entries so that dashboards or monitoring tools can track
+agent behaviour.
+
 ### 🌟 Creating Custom Teams
 
 To design your own workflow start with one of the JSON files under

--- a/src/api.py
+++ b/src/api.py
@@ -54,6 +54,11 @@ def create_app(orchestrator: SolutionOrchestrator | None = None) -> FastAPI:
             raise HTTPException(status_code=404, detail="unknown team")
         return {"team": name, "status": status}
 
+    @app.get("/activity")
+    def get_activity(limit: int = 10, _=Depends(_auth)) -> Dict[str, Any]:
+        """Return recent orchestrator activity."""
+        return {"activity": orch.get_recent_activity(limit)}
+
     return app
 
 

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,6 @@
+"""Utility helpers."""
+
+from .logger import get_logger
+from .activity_logger import ActivityLogger
+
+__all__ = ["get_logger", "ActivityLogger"]

--- a/src/utils/activity_logger.py
+++ b/src/utils/activity_logger.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+"""JSONL based activity logging utility."""
+
+from collections import deque
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from threading import Lock
+from typing import Any, Dict, List
+
+
+class ActivityLogger:
+    """Append structured records to a JSONL log file."""
+
+    def __init__(self, log_path: str | Path) -> None:
+        self.path = Path(log_path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = Lock()
+
+    def log(self, agent_id: str, summary: str, *, ts: datetime | None = None) -> None:
+        """Write a single log entry with ``agent_id`` and ``summary``."""
+        entry = {
+            "timestamp": (ts or datetime.now(timezone.utc)).isoformat(),
+            "agent_id": agent_id,
+            "summary": summary,
+        }
+        line = json.dumps(entry)
+        with self._lock:
+            with self.path.open("a", encoding="utf-8") as fh:
+                fh.write(line + "\n")
+
+    def tail(self, limit: int = 10) -> List[Dict[str, Any]]:
+        """Return the most recent ``limit`` entries."""
+        if not self.path.exists():
+            return []
+        with self.path.open("r", encoding="utf-8") as fh:
+            lines = list(deque(fh, maxlen=limit))
+        return [json.loads(line) for line in lines]

--- a/tests/test_activity_logger.py
+++ b/tests/test_activity_logger.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+from src.utils.activity_logger import ActivityLogger
+
+
+def test_activity_logger(tmp_path: Path):
+    log_file = tmp_path / "log.jsonl"
+    logger = ActivityLogger(log_file)
+
+    logger.log("agent", "did something")
+    logger.log("agent", "second")
+
+    entries = logger.tail(2)
+    assert len(entries) == 2
+    assert entries[0]["agent_id"] == "agent"
+    assert entries[0]["summary"] == "did something"
+    assert "timestamp" in entries[0]


### PR DESCRIPTION
## Summary
- add `ActivityLogger` for JSONL structured logs
- integrate logger into `SolutionOrchestrator`
- expose `/activity` endpoint via FastAPI
- document activity logs in README
- test activity logging and new API route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685433563448832b91b2b9275fdf6a81