### PR TITLE
Add 'assist' CLI subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ brookside-cli send --team sales --event '{"type": "lead_capture", "payload": {"e
 
 # view latest statuses
 brookside-cli status
+
+# map a natural language task to a workflow template
+brookside-cli assist "handle new inventory"
+# => {"template": "src/teams/inventory_management_team.json"}
 ```
 
 ### 🌐 HTTP API
@@ -271,6 +275,7 @@ also included:
 
 * `dev_assist.py` – generate boilerplate modules and matching tests.
 * `debugger_agent.py` – listen for `*.Error` events and propose patches.
+* `brookside-cli assist` – convert plain language tasks into workflow templates.
 * `qa_agent.py` – run scripted conversations against `SupportAgent` and emit QA
   reports.
 * `review_agent.py` – automatically approve or reject drafts published on the event bus.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -82,3 +82,19 @@ def test_cli_start_send_status(tmp_path, monkeypatch):
 
     server.terminate()
     server.wait(timeout=5)
+
+
+def test_cli_assist(tmp_path):
+    """The assist subcommand should map phrases to workflow templates."""
+
+    cmd = [sys.executable, "-m", "src.cli", "assist", "handle new inventory"]
+    res = subprocess.run(cmd, capture_output=True, text=True, timeout=5)
+    assert res.returncode == 0
+    data = json.loads(res.stdout.strip())
+    assert data["template"].endswith("inventory_management_team.json")
+
+    cmd_unknown = [sys.executable, "-m", "src.cli", "assist", "unknown gibberish"]
+    res_unknown = subprocess.run(cmd_unknown, capture_output=True, text=True, timeout=5)
+    assert res_unknown.returncode == 0
+    data_unknown = json.loads(res_unknown.stdout.strip())
+    assert data_unknown["template"] is None


### PR DESCRIPTION
## Summary
- extend CLI with `assist` command for mapping natural language tasks to workflow templates
- document the new feature in the README
- test the assist command

## Testing
- `pytest -q`

------
