### PR TITLE
Add planner dry-run support with CLI and API

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,8 @@ start the orchestrator and send events from another shell:
 
 ```bash
 # launch the orchestrator (listens on localhost:8765)
-brookside-cli start sales=src/teams/sales_team_full.json
+brookside-cli start sales=src/teams/sales_team_full.json --plans planner.json
+# planner.json maps goals to task sequences
 
 # dispatch an event
 brookside-cli send --team sales --event '{"type": "lead_capture", "payload": {"email": "alice@example.com"}}'
@@ -152,6 +153,7 @@ brookside-cli status
 
 # preview a goal without running agents
 brookside-cli goal demo --dry-run
+# drop --dry-run to execute the goal
 ```
 
 ### 🌐 HTTP API

--- a/README.md
+++ b/README.md
@@ -126,6 +126,9 @@ plans = {
 }
 orch = SolutionOrchestrator({"sales": "src/teams/sales_team_full.json"}, planner_plans=plans)
 orch.execute_goal("demo")
+
+# preview the plan without executing any agents
+orch.execute_goal("demo", dry_run=True)
 ```
 
 The planner dispatches each event to the appropriate team in order and returns
@@ -146,6 +149,9 @@ brookside-cli send --team sales --event '{"type": "lead_capture", "payload": {"e
 
 # view latest statuses
 brookside-cli status
+
+# preview a goal without running agents
+brookside-cli goal demo --dry-run
 ```
 
 ### 🌐 HTTP API
@@ -169,6 +175,13 @@ Fetch the latest status:
 
 ```bash
 curl -H "X-API-Key: mysecret" http://localhost:8000/teams/sales/status
+```
+
+Preview a goal without executing agents:
+
+```bash
+curl -H "X-API-Key: mysecret" \
+     -X POST 'http://localhost:8000/goals/demo?dry_run=true'
 ```
 
 ### 🌟 Creating Custom Teams

--- a/docs/agents_overview.md
+++ b/docs/agents_overview.md
@@ -43,7 +43,7 @@ This page lists all of the built-in agents available in the Brookside BI framewo
 * **SupportAgent** (`src/agents/operations/support_agent.py`) – Autonomous Customer Support agent.
 * **RevOpsAgent** (`src/agents/sales/revops_agent.py`) – Revenue operations agent producing pipeline forecasts.
 * **ReviewAgent** (`src/agents/review_agent.py`) – Validates drafts and publishes approval results.
-* **PlannerAgent** (`src/agents/planner_agent.py`) – Executes goal-based plans by sequencing events across teams.
+* **PlannerAgent** (`src/agents/planner_agent.py`) – Executes goal-based plans by sequencing events across teams. Supports `dry_run` to preview the planned sequence without running agents.
 
 ## Key Utilities
 

--- a/src/api.py
+++ b/src/api.py
@@ -54,6 +54,17 @@ def create_app(orchestrator: SolutionOrchestrator | None = None) -> FastAPI:
             raise HTTPException(status_code=404, detail="unknown team")
         return {"team": name, "status": status}
 
+    @app.post("/goals/{goal}")
+    def run_goal(goal: str, dry_run: bool = False, _=Depends(_auth)) -> Dict[str, Any]:
+        """Execute or preview the planner sequence for ``goal``."""
+        try:
+            result = orch.execute_goal(goal, dry_run=dry_run)
+        except RuntimeError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+        if result.get("status") == "unknown_goal":
+            raise HTTPException(status_code=404, detail="unknown goal")
+        return result
+
     return app
 
 

--- a/src/solution_orchestrator.py
+++ b/src/solution_orchestrator.py
@@ -57,8 +57,16 @@ class SolutionOrchestrator:
         """Return last reported status for ``team`` if available."""
         return self.status.get(team)
 
-    def execute_goal(self, goal: str) -> Dict[str, Any]:
-        """Run the planner for the given ``goal``.
+    def execute_goal(self, goal: str, *, dry_run: bool = False) -> Dict[str, Any]:
+        """Run or preview the planner for the given ``goal``.
+
+        Parameters
+        ----------
+        goal:
+            Name of the goal to execute.
+        dry_run:
+            When ``True`` return the planned sequence without executing any
+            agents.
 
         Raises
         ------
@@ -68,4 +76,4 @@ class SolutionOrchestrator:
 
         if not self.planner:
             raise RuntimeError("Planner is not configured")
-        return self.planner.run({"goal": goal})
+        return self.planner.run({"goal": goal}, dry_run=dry_run)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,6 +14,7 @@ from urllib import request as urllib_request
 from src.solution_orchestrator import SolutionOrchestrator
 from src import api
 
+
 def _http_get(url: str, headers: dict[str, str] | None = None) -> tuple[int, str]:
     req = urllib_request.Request(url, headers=headers or {})
     try:
@@ -23,15 +24,20 @@ def _http_get(url: str, headers: dict[str, str] | None = None) -> tuple[int, str
         return err.code, err.read().decode()
 
 
-def _http_post(url: str, data: dict, headers: dict[str, str] | None = None) -> tuple[int, str]:
+def _http_post(
+    url: str, data: dict, headers: dict[str, str] | None = None
+) -> tuple[int, str]:
     payload = json.dumps(data).encode()
-    req = urllib_request.Request(url, data=payload, headers=headers or {}, method="POST")
+    req = urllib_request.Request(
+        url, data=payload, headers=headers or {}, method="POST"
+    )
     req.add_header("Content-Type", "application/json")
     try:
         with urllib_request.urlopen(req) as resp:  # noqa: S310 -- in tests
             return resp.getcode(), resp.read().decode()
     except urllib_request.HTTPError as err:  # type: ignore[attr-defined]
         return err.code, err.read().decode()
+
 
 from src.agents.base_agent import BaseAgent
 
@@ -171,6 +177,49 @@ def test_goal_dry_run(tmp_path):
         data = json.loads(body)
         assert data["status"] == "planned"
         assert data["sequence"] == [{"team": "demo", "event": "echo_agent"}]
+    finally:
+        server.should_exit = True
+        thread.join(timeout=5)
+
+
+def test_goal_unknown(tmp_path):
+    _register_agent()
+    team_cfg = _write_team(tmp_path)
+    port = _get_free_port()
+    plans = {"demo": []}
+    orch = SolutionOrchestrator({"demo": str(team_cfg)}, planner_plans=plans)
+    api.settings.API_AUTH_KEY = "secret"
+    app = api.create_app(orch)
+    server, thread = _start_server(app, port)
+
+    try:
+        code, _ = _http_post(
+            f"http://127.0.0.1:{port}/goals/missing",
+            {},
+            headers={"X-API-Key": "secret"},
+        )
+        assert code == 404
+    finally:
+        server.should_exit = True
+        thread.join(timeout=5)
+
+
+def test_goal_no_planner(tmp_path):
+    _register_agent()
+    team_cfg = _write_team(tmp_path)
+    port = _get_free_port()
+    orch = SolutionOrchestrator({"demo": str(team_cfg)})
+    api.settings.API_AUTH_KEY = "secret"
+    app = api.create_app(orch)
+    server, thread = _start_server(app, port)
+
+    try:
+        code, _ = _http_post(
+            f"http://127.0.0.1:{port}/goals/demo",
+            {},
+            headers={"X-API-Key": "secret"},
+        )
+        assert code == 400
     finally:
         server.should_exit = True
         thread.join(timeout=5)


### PR DESCRIPTION
## Summary
- implement dry-run mode in `PlannerAgent` and `SolutionOrchestrator`
- expose new planner endpoint in the FastAPI app
- extend CLI with `goal` command and optional `--dry-run`
- document the new options and update examples
- add unit tests for planner dry-run and API endpoint

## Testing
- `pytest -q`

------
