### PR TITLE
Add web config editor and API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,8 +289,8 @@ to extend them.
 ## 🛠 Web Configuration
 
 A lightweight React page in `webui/` allows non-developers to edit team JSON files
-and environment variables without touching Python code. Start the API server and
-open the editor:
+and environment variables without touching Python code. Start the API server, which
+now enables CORS so the editor can talk to it directly, then open the page:
 
 ```bash
 python -m src.api  # exposes /config endpoints

--- a/docs/config_editor.md
+++ b/docs/config_editor.md
@@ -4,7 +4,9 @@ A lightweight React page (`webui/index.html`) allows non-developers to adjust ag
 
 ## Running the API
 
-Start the FastAPI server exposing the new configuration endpoints:
+Start the FastAPI server exposing the new configuration endpoints. CORS support
+is enabled so the static editor can communicate with the API when opened from
+``file://`` or another domain:
 
 ```bash
 python -m src.api
@@ -17,6 +19,8 @@ Provide the `X-API-Key` header set to `API_AUTH_KEY` from your `.env` file.
 Open `webui/index.html` in your browser. Enter the API key when prompted and the page will list available team configuration files from `src/teams/` and the current environment settings.
 
 1. **Teams** – select a team to view and edit its JSON. Press **Save Team** to persist changes back to disk.
-2. **Environment Settings** – modify key/value pairs in JSON form and click **Save Settings**. The values are written to the `.env` file used by the CLI and Python modules.
+2. **Environment Settings** – modify key/value pairs in JSON form and click
+   **Save Settings**. Values are merged into the existing `.env` file so any
+   other variables remain intact.
 
 The CLI automatically reads these files, so updates made through the web UI take effect the next time the orchestrator or tests are run.

--- a/src/config.py
+++ b/src/config.py
@@ -54,6 +54,15 @@ def _load_env_file(path: str) -> dict[str, str]:
     return data
 
 
+def update_env_file(path: str, values: dict[str, str]) -> None:
+    """Merge ``values`` with existing ``path`` contents and persist."""
+    env = _load_env_file(path)
+    env.update({str(k): str(v) for k, v in values.items()})
+    with open(path, "w") as f:
+        for key, val in env.items():
+            f.write(f"{key}={val}\n")
+
+
 class Settings(BaseSettings):
     """Application settings loaded from environment variables."""
 

--- a/webui/index.html
+++ b/webui/index.html
@@ -14,6 +14,8 @@
   <body>
     <div id="app"></div>
     <script type="text/babel">
+    // Update API_BASE if the API is hosted on a different origin
+    const API_BASE = '';
     function App() {
       const [apiKey, setApiKey] = React.useState('');
       const [teams, setTeams] = React.useState([]);
@@ -23,11 +25,11 @@
 
       React.useEffect(() => {
         if (!apiKey) return;
-        fetch('/config/teams', {headers: {'X-API-Key': apiKey}})
+        fetch(`${API_BASE}/config/teams`, {headers: {'X-API-Key': apiKey}})
           .then(r => r.json())
           .then(setTeams)
           .catch(console.error);
-        fetch('/config/settings', {headers: {'X-API-Key': apiKey}})
+        fetch(`${API_BASE}/config/settings`, {headers: {'X-API-Key': apiKey}})
           .then(r => r.json())
           .then(s => setSettings(JSON.stringify(s, null, 2)))
           .catch(console.error);
@@ -35,14 +37,14 @@
 
       function loadTeam(name) {
         setCurrentTeam(name);
-        fetch(`/config/teams/${name}`, {headers: {'X-API-Key': apiKey}})
+        fetch(`${API_BASE}/config/teams/${name}`, {headers: {'X-API-Key': apiKey}})
           .then(r => r.json())
           .then(cfg => setTeamConfig(JSON.stringify(cfg, null, 2)))
           .catch(console.error);
       }
 
       function saveTeam() {
-        fetch(`/config/teams/${currentTeam}`, {
+        fetch(`${API_BASE}/config/teams/${currentTeam}`, {
           method: 'PUT',
           headers: {'Content-Type': 'application/json', 'X-API-Key': apiKey},
           body: teamConfig
@@ -50,7 +52,7 @@
       }
 
       function saveSettings() {
-        fetch('/config/settings', {
+        fetch(`${API_BASE}/config/settings`, {
           method: 'PUT',
           headers: {'Content-Type': 'application/json', 'X-API-Key': apiKey},
           body: settings


### PR DESCRIPTION
## Summary
- provide FastAPI endpoints for reading and writing team JSON files and `.env` settings
- document how to use the new editor
- add simple React page under `webui/`
- test the configuration endpoints

## Testing
- `black --check src/api.py tests/test_api_config.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854335fba74832b8f00d2efd523c1f8