### PR TITLE
Add workflow blueprint API and Streamlit UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,8 @@ curl -H "X-API-Key: mysecret" http://localhost:8000/workflows/load/demo
 ```
 
 Blueprints live under the `workflows/` folder by default (override with the
-`WORKFLOWS_DIR` environment variable). Launch the included Streamlit UI for a
+`WORKFLOWS_DIR` environment variable). The API will create this directory on
+first use if it does not already exist. Launch the included Streamlit UI for a
 simple editor:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -182,8 +182,9 @@ curl -H "X-API-Key: mysecret" \
 curl -H "X-API-Key: mysecret" http://localhost:8000/workflows/load/demo
 ```
 
-Blueprints live under the `workflows/` folder. Launch the included Streamlit UI
-for a simple editor:
+Blueprints live under the `workflows/` folder by default (override with the
+`WORKFLOWS_DIR` environment variable). Launch the included Streamlit UI for a
+simple editor:
 
 ```bash
 streamlit run src/workflow_ui.py
@@ -250,6 +251,7 @@ dotenv file before running the orchestrator or tests.
 | `SLACK_WEBHOOK_URL` | Post notifications to Slack channels |
 | `TEAMS_WEBHOOK_URL` | Microsoft Teams notifications |
 | `PROMETHEUS_PUSHGATEWAY` | Metrics aggregation endpoint |
+| `WORKFLOWS_DIR` | Where workflow blueprints are stored |
 | `MLS_API_URL` / `MLS_API_KEY` | Real estate data feed |
 
 For an exhaustive description of all variables see

--- a/README.md
+++ b/README.md
@@ -171,6 +171,24 @@ Fetch the latest status:
 curl -H "X-API-Key: mysecret" http://localhost:8000/teams/sales/status
 ```
 
+#### Workflow Blueprints
+
+Two helper endpoints make it easy to store and retrieve planner blueprints:
+
+```bash
+curl -H "X-API-Key: mysecret" \
+     -X POST http://localhost:8000/workflows/save \
+     -d '{"name": "demo", "blueprint": {"steps": []}}'
+curl -H "X-API-Key: mysecret" http://localhost:8000/workflows/load/demo
+```
+
+Blueprints live under the `workflows/` folder. Launch the included Streamlit UI
+for a simple editor:
+
+```bash
+streamlit run src/workflow_ui.py
+```
+
 ### 🌟 Creating Custom Teams
 
 To design your own workflow start with one of the JSON files under
@@ -211,6 +229,7 @@ The optional packages listed in that file (such as `openai` and `google-api-pyth
 | `openai` | LLM backed agents and chat completions |
 | `google-api-python-client` | Google Calendar and other Google service integrations |
 | `requests` | HTTP-based memory service |
+| `streamlit` | Local blueprint management UI |
 
 ## 📐 Environment Variables
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ openai>=1.0.0  # optional - used by ChatTool
 google-api-python-client>=2.0.0  # optional - for Google Calendar
 fastapi>=0.110.0  # memory service server
 uvicorn>=0.22.0
+streamlit>=1.30.0
 

--- a/src/config.py
+++ b/src/config.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 from typing import Literal, Optional
 import os
+from pathlib import Path
 
 from pydantic import BaseSettings, Field, validator
 
@@ -170,6 +171,7 @@ class Settings(BaseSettings):
     MEMORY_BACKEND: Literal["rest", "file"] = "rest"
     MEMORY_ENDPOINT: str = "http://localhost:8000"
     MEMORY_FILE_PATH: str = "memory.jsonl"
+    WORKFLOWS_DIR: str = str(Path(__file__).resolve().parent.parent / "workflows")
 
     # Logistics & E-commerce
     TMS_API_URL: Optional[str] = None

--- a/src/workflow_ui.py
+++ b/src/workflow_ui.py
@@ -12,7 +12,9 @@ from typing import Dict, Any
 
 import streamlit as st
 
-WORKFLOWS_DIR = Path("workflows")
+from src.config import settings
+
+WORKFLOWS_DIR = Path(settings.WORKFLOWS_DIR)
 WORKFLOWS_DIR.mkdir(exist_ok=True)
 
 st.title("Workflow Manager")

--- a/src/workflow_ui.py
+++ b/src/workflow_ui.py
@@ -1,0 +1,50 @@
+"""Streamlit interface for managing workflow blueprints.
+
+Run with:
+    streamlit run src/workflow_ui.py
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Any
+
+import streamlit as st
+
+WORKFLOWS_DIR = Path("workflows")
+WORKFLOWS_DIR.mkdir(exist_ok=True)
+
+st.title("Workflow Manager")
+
+existing = [p.stem for p in WORKFLOWS_DIR.glob("*.json")]
+selected = st.selectbox("Existing workflows", ["<new>"] + existing)
+
+name = st.text_input("Name", value="" if selected == "<new>" else selected)
+
+content: str = ""
+if selected != "<new>" and (WORKFLOWS_DIR / f"{selected}.json").exists():
+    content = (WORKFLOWS_DIR / f"{selected}.json").read_text()
+
+blueprint_text = st.text_area("Blueprint JSON", value=content, height=300)
+
+col1, col2 = st.columns(2)
+
+with col1:
+    if st.button("Load") and selected != "<new>":
+        st.experimental_rerun()
+
+with col2:
+    if st.button("Save"):
+        if not name:
+            st.error("Name is required")
+        else:
+            try:
+                data: Dict[str, Any] = json.loads(blueprint_text or "{}")
+            except json.JSONDecodeError as exc:
+                st.error(f"Invalid JSON: {exc}")
+            else:
+                path = WORKFLOWS_DIR / f"{Path(name).stem}.json"
+                path.write_text(json.dumps(data, indent=2))
+                st.success(f"Saved to {path}")
+                st.experimental_rerun()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -159,7 +159,7 @@ def test_unknown_team(tmp_path):
 
 def test_workflow_save_and_load(tmp_path):
     port = _get_free_port()
-    api.WORKFLOWS_DIR = Path(tmp_path)
+    api.settings.WORKFLOWS_DIR = str(tmp_path)
     app = api.create_app(SolutionOrchestrator({}))
     api.settings.API_AUTH_KEY = "secret"
     server, thread = _start_server(app, port)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,6 +14,7 @@ from urllib import request as urllib_request
 from src.solution_orchestrator import SolutionOrchestrator
 from src import api
 
+
 def _http_get(url: str, headers: dict[str, str] | None = None) -> tuple[int, str]:
     req = urllib_request.Request(url, headers=headers or {})
     try:
@@ -23,15 +24,20 @@ def _http_get(url: str, headers: dict[str, str] | None = None) -> tuple[int, str
         return err.code, err.read().decode()
 
 
-def _http_post(url: str, data: dict, headers: dict[str, str] | None = None) -> tuple[int, str]:
+def _http_post(
+    url: str, data: dict, headers: dict[str, str] | None = None
+) -> tuple[int, str]:
     payload = json.dumps(data).encode()
-    req = urllib_request.Request(url, data=payload, headers=headers or {}, method="POST")
+    req = urllib_request.Request(
+        url, data=payload, headers=headers or {}, method="POST"
+    )
     req.add_header("Content-Type", "application/json")
     try:
         with urllib_request.urlopen(req) as resp:  # noqa: S310 -- in tests
             return resp.getcode(), resp.read().decode()
     except urllib_request.HTTPError as err:  # type: ignore[attr-defined]
         return err.code, err.read().decode()
+
 
 from src.agents.base_agent import BaseAgent
 
@@ -143,6 +149,39 @@ def test_unknown_team(tmp_path):
         code, _ = _http_post(
             f"http://127.0.0.1:{port}/teams/missing/event",
             {"type": "x"},
+            headers={"X-API-Key": "secret"},
+        )
+        assert code == 404
+    finally:
+        server.should_exit = True
+        thread.join(timeout=5)
+
+
+def test_workflow_save_and_load(tmp_path):
+    port = _get_free_port()
+    api.WORKFLOWS_DIR = Path(tmp_path)
+    app = api.create_app(SolutionOrchestrator({}))
+    api.settings.API_AUTH_KEY = "secret"
+    server, thread = _start_server(app, port)
+
+    try:
+        payload = {"name": "demo", "blueprint": {"steps": [1]}}
+        code, _ = _http_post(
+            f"http://127.0.0.1:{port}/workflows/save",
+            payload,
+            headers={"X-API-Key": "secret"},
+        )
+        assert code == 200
+
+        code, body = _http_get(
+            f"http://127.0.0.1:{port}/workflows/load/demo",
+            headers={"X-API-Key": "secret"},
+        )
+        assert code == 200
+        assert json.loads(body)["steps"] == [1]
+
+        code, _ = _http_get(
+            f"http://127.0.0.1:{port}/workflows/load/missing",
             headers={"X-API-Key": "secret"},
         )
         assert code == 404

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -188,3 +188,26 @@ def test_workflow_save_and_load(tmp_path):
     finally:
         server.should_exit = True
         thread.join(timeout=5)
+
+
+def test_save_creates_directory(tmp_path):
+    """Saving a workflow should create ``WORKFLOWS_DIR`` if missing."""
+    port = _get_free_port()
+    dir_path = tmp_path / "missing"
+    api.settings.WORKFLOWS_DIR = str(dir_path)
+    app = api.create_app(SolutionOrchestrator({}))
+    api.settings.API_AUTH_KEY = "secret"
+    server, thread = _start_server(app, port)
+
+    try:
+        payload = {"name": "demo", "blueprint": {"steps": [1]}}
+        code, _ = _http_post(
+            f"http://127.0.0.1:{port}/workflows/save",
+            payload,
+            headers={"X-API-Key": "secret"},
+        )
+        assert code == 200
+        assert dir_path.exists()
+    finally:
+        server.should_exit = True
+        thread.join(timeout=5)


### PR DESCRIPTION
## Summary
- implement `/workflows/save` and `/workflows/load` endpoints
- store workflow JSON files under `workflows/`
- add Streamlit UI for editing blueprints
- document new endpoints and optional package
- expand API tests for workflow persistence

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854335ea2b0832b9aa1017147bc67b4