### PR TITLE
Add chat context summarisation helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ also included:
 * `qa_agent.py` – run scripted conversations against `SupportAgent` and emit QA
   reports.
 * `review_agent.py` – automatically approve or reject drafts published on the event bus.
+* `utils.context.summarize_messages` – keeps chat histories within sensible token limits by inserting summaries when needed.
 
 These helper scripts keep network calls behind feature flags so they remain
 test-safe by default.

--- a/docs/agents_overview.md
+++ b/docs/agents_overview.md
@@ -6,7 +6,7 @@ This page lists all of the built-in agents available in the Brookside BI framewo
 
 * **AnalyticsAgent** (`src/agents/sales/analytics_agent.py`) – Push a metric to Prometheus via the PrometheusPusher tool.
 * **BaseAgent** (`src/agents/base_agent.py`) – Common abstract base class for all agents used in the examples.
-* **ChatbotAgent** (`src/agents/sales/chatbot_agent.py`) – Agent wrapping a very small OpenAI `ChatCompletion` invocation.
+* **ChatbotAgent** (`src/agents/sales/chatbot_agent.py`) – Agent wrapping a very small OpenAI `ChatCompletion` invocation. Automatically trims conversation history using `utils.context.summarize_messages`.
 * **ContractAgent** (`src/agents/sales/contract_agent.py`) – Handles contract operations.
 * **ContractSignMonitorAgent** (`src/agents/sales/contract_sign_monitor_agent.py`) – Handles contract sign monitor operations.
 * **CRMEntryAgent** (`src/agents/sales/crm_entry_agent.py`) – Handles crmentry operations.

--- a/src/agents/sales/chatbot_agent.py
+++ b/src/agents/sales/chatbot_agent.py
@@ -3,7 +3,7 @@
 from ..base_agent import BaseAgent
 import importlib
 from ...utils.logger import get_logger
-from ...utils.context import summarise_messages
+from ...utils.context import summarize_messages
 from ...events import ChatbotEvent
 
 logger = get_logger(__name__)
@@ -29,7 +29,7 @@ class ChatbotAgent(BaseAgent):
 
         logger.info("Running ChatbotAgent")
         # ensure conversation stays within reasonable bounds
-        messages = summarise_messages(payload.messages)
+        messages = summarize_messages(payload.messages)
 
         # forward the messages to ChatTool which wraps the OpenAI call
         response = self.chat_tool.chat(messages)

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,6 +1,6 @@
 """Utility package exposing common helpers."""
 
 from .logger import get_logger
-from .context import summarise_messages
+from .context import summarize_messages, summarise_messages
 
-__all__ = ["get_logger", "summarise_messages"]
+__all__ = ["get_logger", "summarize_messages", "summarise_messages"]

--- a/src/utils/context.py
+++ b/src/utils/context.py
@@ -32,7 +32,7 @@ def _simple_summary(texts: List[str], max_tokens: int) -> str:
     return " ".join(words)
 
 
-def summarise_messages(
+def summarize_messages(
     messages: List[Dict[str, str]],
     *,
     max_tokens: int = 2000,
@@ -70,9 +70,31 @@ def summarise_messages(
     while current and total_tokens(current) > max_tokens - summary_tokens:
         removed.append(current.pop(0))
 
-    summary_text = _simple_summary([m.get("content", "") for m in removed], summary_tokens)
+    summary_text = _simple_summary(
+        [m.get("content", "") for m in removed], summary_tokens
+    )
     summary_msg = {
         "role": "system",
         "content": f"Summary of earlier messages: {summary_text}",
     }
     return [summary_msg] + current
+
+
+# ---------------------------------------------------------------------------
+# Backwards compatibility
+# ---------------------------------------------------------------------------
+
+
+def summarise_messages(
+    messages: List[Dict[str, str]],
+    *,
+    max_tokens: int = 2000,
+    summary_tokens: int = 200,
+) -> List[Dict[str, str]]:
+    """Alias for :func:`summarize_messages` using UK spelling."""
+
+    return summarize_messages(
+        messages,
+        max_tokens=max_tokens,
+        summary_tokens=summary_tokens,
+    )

--- a/tests/test_context_utils.py
+++ b/tests/test_context_utils.py
@@ -1,14 +1,22 @@
-from src.utils.context import summarise_messages
+from src.utils.context import summarize_messages, summarise_messages
 
 
 def test_summarise_messages_no_trim():
     msgs = [{"role": "user", "content": "hello world"}]
-    out = summarise_messages(msgs, max_tokens=10)
+    out = summarize_messages(msgs, max_tokens=10)
     assert out == msgs
+
 
 def test_summarise_messages_trimmed():
     msgs = [{"role": "user", "content": "word " * 20}] * 6
-    out = summarise_messages(msgs, max_tokens=50, summary_tokens=5)
+    out = summarize_messages(msgs, max_tokens=50, summary_tokens=5)
     assert out[0]["role"] == "system"
     assert "Summary" in out[0]["content"]
     assert len(out) < len(msgs)
+
+
+def test_summarise_messages_alias():
+    msgs = [{"role": "user", "content": "hello world"}]
+    out1 = summarize_messages(msgs, max_tokens=10)
+    out2 = summarise_messages(msgs, max_tokens=10)
+    assert out1 == out2


### PR DESCRIPTION
## Summary
- introduce `src/utils/context.summarise_messages` for trimming long chat histories
- wire summarisation into `ChatbotAgent`
- expose helper via `utils.__init__`
- test the new context utility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685433542ed4832b81d9325ee7769b40