### PR TITLE
Fix direct execution of CLI and API modules

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -1,14 +1,28 @@
 from __future__ import annotations
 
-"""HTTP interface exposing :class:`SolutionOrchestrator` via FastAPI."""
+"""HTTP interface exposing :class:`SolutionOrchestrator` via FastAPI.
+
+This module supports being executed directly as ``python src/api.py`` or via
+``python -m src.api``. When run as a script the ``src`` package may not be on
+``sys.path`` which breaks the relative imports below. The bootstrap logic adds
+the project root to ``sys.path`` so the package layout remains valid in both
+scenarios. This mirrors the behaviour of ``python -m`` but allows direct script
+execution as well.
+"""
+
+from pathlib import Path
+import os
+import sys
+
+if __package__ in {None, ""}:  # pragma: no cover - safe for direct execution
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    __package__ = "src"
 
 from typing import Any, Dict, List, Literal
-import os
 import json
 
 from fastapi import Depends, FastAPI, Header, HTTPException
 from pydantic import BaseModel
-from pathlib import Path
 
 
 class Event(BaseModel):

--- a/src/cli.py
+++ b/src/cli.py
@@ -7,7 +7,12 @@ import asyncio
 import json
 import socket
 import sys
+from pathlib import Path
 from typing import Dict, Iterable, Tuple
+
+if __package__ in {None, ""}:  # pragma: no cover - script execution support
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    __package__ = "src"
 
 
 

--- a/src/cli_assistant.py
+++ b/src/cli_assistant.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from pathlib import Path
+
+if __package__ in {None, ""}:  # pragma: no cover - script execution support
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    __package__ = "src"
 
 from .utils.nlp_params import parse_parameters
 

--- a/tests/test_script_execution.py
+++ b/tests/test_script_execution.py
@@ -1,0 +1,19 @@
+import json
+import subprocess
+import sys
+
+
+def test_cli_assistant_direct_execution():
+    cmd = [sys.executable, 'src/cli_assistant.py', 'Budget $50 targeting parents']
+    res = subprocess.run(cmd, capture_output=True, text=True, timeout=5)
+    assert res.returncode == 0
+    data = json.loads(res.stdout.strip())
+    assert data['budget'] == 50
+
+
+def test_cli_direct_execution():
+    cmd = [sys.executable, 'src/cli.py', 'assist', 'handle new inventory']
+    res = subprocess.run(cmd, capture_output=True, text=True, timeout=5)
+    assert res.returncode == 0
+    data = json.loads(res.stdout.strip())
+    assert data['template'].endswith('inventory_management_team.json')


### PR DESCRIPTION
## Summary
- ensure `src.api`, `src.cli`, and `src.cli_assistant` work when executed directly
- add regression tests for running CLI modules as scripts

## Testing
- `pytest -q`

------
