### PR TITLE
Add visitor analytics integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ dotenv file before running the orchestrator or tests.
 | `SLACK_WEBHOOK_URL` | Post notifications to Slack channels |
 | `TEAMS_WEBHOOK_URL` | Microsoft Teams notifications |
 | `PROMETHEUS_PUSHGATEWAY` | Metrics aggregation endpoint |
+| `VISITOR_ANALYTICS_URL` / `VISITOR_ANALYTICS_KEY` | Visitor tracking analytics configuration |
 | `MLS_API_URL` / `MLS_API_KEY` | Real estate data feed |
 
 For an exhaustive description of all variables see

--- a/docs/agents_overview.md
+++ b/docs/agents_overview.md
@@ -27,7 +27,7 @@ This page lists all of the built-in agents available in the Brookside BI framewo
 * **SchedulingAgent** (`src/agents/sales/scheduling_agent.py`) – Handles scheduling operations.
 * **SegmentationAdTargetingAgent** (`src/agents/sales/segmentation_ad_targeting_agent.py`) – Create ad campaigns for multiple audience segments.
 * **UpsellAgent** (`src/agents/sales/upsell_agent.py`) – Handles upsell operations.
-* **VisitorTrackingAgent** (`src/agents/sales/visitor_tracking_agent.py`) – Handles visitor tracking operations.
+* **VisitorTrackingAgent** (`src/agents/sales/visitor_tracking_agent.py`) – Logs visitor activity and forwards events to your analytics service.
 * **RealEstateLeadAgent** (`src/agents/real_estate/real_estate_lead_agent.py`) – Locate potential real-estate buyers or sellers.
 * **MLSAgent** (`src/agents/real_estate/mls_agent.py`) – Agent that pulls listing data from the MLS.
 * **ListingAgent** (`src/agents/real_estate/listing_agent.py`) – Construct simple listing dictionaries for property data.

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -94,6 +94,8 @@ variables documented below.
 - `MIXPANEL_TOKEN` – Mixpanel project token.
 - `SEGMENT_WRITE_KEY` – Segment write key.
 - `AMPLITUDE_API_KEY` – Amplitude API key.
+- `VISITOR_ANALYTICS_URL` – HTTP endpoint for storing visitor events.
+- `VISITOR_ANALYTICS_KEY` – Bearer token for the analytics service.
 - `IPINFO_TOKEN` – ipinfo.io token.
 - `UA_PARSER_REGEX_PATH` – Optional path to UA parser regexes.
 

--- a/src/agents/sales/visitor_tracking_agent.py
+++ b/src/agents/sales/visitor_tracking_agent.py
@@ -2,13 +2,39 @@
 
 from ..base_agent import BaseAgent
 from ...utils.logger import get_logger
+from ...tools.visitor_tracking_tools import AnalyticsClient
 
 logger = get_logger(__name__)
 
 
 class VisitorTrackingAgent(BaseAgent):
+    """Log visitor data and forward it to the configured analytics service."""
+
+    def __init__(self) -> None:
+        self.analytics = AnalyticsClient()
+
     def run(self, payload):
-        # payload: { "visitor_id": "...", "page": "...", "timestamp": "..." }
-        logger.info(f"Tracked visitor {payload['visitor_id']} at {payload['page']}")
-        # TODO: integrate FingerprintJS or analytics SDK
-        return {"status": "logged", **payload}
+        """Process a visitor event.
+
+        Parameters
+        ----------
+        payload: dict
+            ``{"visitor_id": str, "page": str, "timestamp": str}``
+
+        Returns
+        -------
+        dict
+            Includes ``status`` and ``analytics_sent`` boolean flag.
+        """
+
+        logger.info(
+            "Tracked visitor %s at %s", payload.get("visitor_id"), payload.get("page")
+        )
+
+        try:
+            sent = self.analytics.track(payload)
+        except Exception as exc:  # pragma: no cover - analytics client bug
+            logger.error("Analytics client failure: %s", exc)
+            sent = False
+
+        return {"status": "logged", "analytics_sent": sent, **payload}

--- a/src/config.py
+++ b/src/config.py
@@ -132,6 +132,8 @@ class Settings(BaseSettings):
     MIXPANEL_TOKEN: Optional[str] = None
     SEGMENT_WRITE_KEY: Optional[str] = None
     AMPLITUDE_API_KEY: Optional[str] = None
+    VISITOR_ANALYTICS_URL: Optional[str] = None
+    VISITOR_ANALYTICS_KEY: Optional[str] = None
     IPINFO_TOKEN: Optional[str] = None
     UA_PARSER_REGEX_PATH: str = ""
 

--- a/src/tools/visitor_tracking_tools/__init__.py
+++ b/src/tools/visitor_tracking_tools/__init__.py
@@ -1,0 +1,5 @@
+
+from .session_stitcher import SessionStitcher
+from .analytics_client import AnalyticsClient
+
+__all__ = ["SessionStitcher", "AnalyticsClient"]

--- a/src/tools/visitor_tracking_tools/analytics_client.py
+++ b/src/tools/visitor_tracking_tools/analytics_client.py
@@ -1,0 +1,60 @@
+# Tools/visitor_tracking_tools/analytics_client.py
+"""Simple HTTP client for forwarding visitor data to an analytics service."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import requests
+
+from ...config import settings
+from ...utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class AnalyticsClient:
+    """Send visitor tracking data to an external analytics endpoint."""
+
+    def __init__(self) -> None:
+        self.endpoint = settings.VISITOR_ANALYTICS_URL
+        self.api_key = settings.VISITOR_ANALYTICS_KEY
+
+    def track(self, data: dict[str, Any], retries: int = 3) -> bool:
+        """POST ``data`` to the configured endpoint.
+
+        Parameters
+        ----------
+        data:
+            Visitor payload to forward.
+        retries:
+            Number of attempts before giving up. Sleeps one second between
+            attempts.
+
+        Returns
+        -------
+        bool
+            ``True`` if the request succeeded, ``False`` otherwise.
+        """
+
+        if not self.endpoint:
+            logger.warning("VISITOR_ANALYTICS_URL not configured; skipping send")
+            return False
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}"
+        } if self.api_key else {}
+
+        for attempt in range(1, retries + 1):
+            try:
+                resp = requests.post(self.endpoint, json=data, headers=headers, timeout=5)
+                resp.raise_for_status()
+                logger.info(
+                    "Visitor analytics sent successfully (attempt %s)", attempt
+                )
+                return True
+            except Exception as exc:  # pragma: no cover - network failures
+                logger.error("Analytics send failed on attempt %s: %s", attempt, exc)
+                time.sleep(1)
+        return False

--- a/tests/test_visitor_tracking_agent.py
+++ b/tests/test_visitor_tracking_agent.py
@@ -1,0 +1,63 @@
+import logging
+import sys
+import types
+
+# Provide a minimal 'requests' stub so importing the analytics client does not fail
+sys.modules.setdefault(
+    "requests",
+    types.SimpleNamespace(
+        post=lambda *a, **k: types.SimpleNamespace(
+            ok=True, json=lambda: {}, raise_for_status=lambda: None
+        )
+    ),
+)
+
+from src.agents.sales.visitor_tracking_agent import VisitorTrackingAgent
+
+
+class DummyAnalytics:
+    def __init__(self):
+        self.calls = []
+
+    def track(self, data, retries: int = 3):
+        self.calls.append(data)
+        return True
+
+
+def test_visitor_tracking_success(monkeypatch, caplog):
+    dummy = DummyAnalytics()
+    monkeypatch.setattr(
+        "src.agents.sales.visitor_tracking_agent.AnalyticsClient", lambda: dummy
+    )
+
+    agent = VisitorTrackingAgent()
+    payload = {"visitor_id": "v1", "page": "/", "timestamp": "t"}
+    with caplog.at_level(logging.INFO):
+        result = agent.run(payload)
+
+    assert result["status"] == "logged"
+    assert result["analytics_sent"] is True
+    assert dummy.calls == [payload]
+    assert any("Tracked visitor" in r.message for r in caplog.records)
+
+
+class FailingAnalytics(DummyAnalytics):
+    def track(self, data, retries: int = 3):
+        raise RuntimeError("boom")
+
+
+def test_visitor_tracking_failure(monkeypatch, caplog):
+    dummy = FailingAnalytics()
+    monkeypatch.setattr(
+        "src.agents.sales.visitor_tracking_agent.AnalyticsClient", lambda: dummy
+    )
+
+    agent = VisitorTrackingAgent()
+    payload = {"visitor_id": "v2", "page": "/err", "timestamp": "t"}
+    with caplog.at_level(logging.ERROR):
+        result = agent.run(payload)
+
+    assert result["analytics_sent"] is False
+    # should still include original payload
+    assert result["visitor_id"] == "v2"
+    assert any("Analytics client failure" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- send visitor data to analytics endpoint via new `AnalyticsClient`
- retry analytics requests and handle failures gracefully
- expose `VISITOR_ANALYTICS_URL` and `VISITOR_ANALYTICS_KEY` in config
- document new configuration options and update agent overview
- test visitor tracking agent with mocked analytics client

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854876b82b0832b824674a083398087