### PR TITLE
Implement AdTool APIs with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,8 @@ dotenv file before running the orchestrator or tests.
 | `MEMORY_REDIS_URL` | Redis connection when `MEMORY_BACKEND=redis` |
 | `SLACK_WEBHOOK_URL` | Post notifications to Slack channels |
 | `TEAMS_WEBHOOK_URL` | Microsoft Teams notifications |
+| `FACEBOOK_ACCESS_TOKEN` | Used by `AdTool` to create Facebook campaigns |
+| `GOOGLE_ADS_API_KEY` | Used by `AdTool` to create Google campaigns |
 | `PROMETHEUS_PUSHGATEWAY` | Metrics aggregation endpoint |
 | `MLS_API_URL` / `MLS_API_KEY` | Real estate data feed |
 

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -35,8 +35,8 @@ variables documented below.
 - `SF_DOMAIN` – Salesforce domain, defaults to `login.salesforce.com`.
 
 ## Advertising & Social Platforms
-- `FACEBOOK_ACCESS_TOKEN` – Access token for Facebook APIs.
-- `GOOGLE_ADS_API_KEY` – Google Ads API key.
+- `FACEBOOK_ACCESS_TOKEN` – Access token for Facebook APIs used by `AdTool`.
+- `GOOGLE_ADS_API_KEY` – Google Ads API key used by `AdTool`.
 
 ## Real Estate APIs
 - `MLS_API_URL` – Base URL for the MLS data feed.

--- a/src/tools/ad_tool.py
+++ b/src/tools/ad_tool.py
@@ -1,6 +1,9 @@
 """Utility for creating simple ad campaigns on Facebook and Google."""
 
 import logging
+from typing import Any, Dict, Optional
+
+import requests
 from ..config import settings
 
 logger = logging.getLogger(__name__)
@@ -14,14 +17,100 @@ class AdTool:
 
     def create_facebook_campaign(
         self, name: str, audience_ids: list, budget: int
-    ) -> dict:
-        logger.info(f"Creating FB campaign {name} for audiences {audience_ids}")
-        # TODO: call Facebook Marketing API here
-        campaign_id = f"fb_{name.lower().replace(' ','_')}"
-        return {"platform": "facebook", "campaign_id": campaign_id, "status": "created"}
+    ) -> Dict[str, Optional[Any]]:
+        """Create a basic Facebook campaign.
 
-    def create_google_campaign(self, name: str, keywords: list, budget: int) -> dict:
-        logger.info(f"Creating Google Ads campaign {name} on keywords {keywords}")
-        # TODO: call Google Ads API here
-        campaign_id = f"ga_{name.lower().replace(' ','_')}"
-        return {"platform": "google", "campaign_id": campaign_id, "status": "created"}
+        Parameters
+        ----------
+        name:
+            Human friendly campaign name.
+        audience_ids:
+            Facebook custom audience identifiers.
+        budget:
+            Daily budget in the smallest currency unit.
+
+        Returns
+        -------
+        dict
+            ``{"platform": "facebook", "campaign_id": str | None, "status": str, "message": str | None}``
+        """
+
+        logger.info(
+            "Creating FB campaign %s for audiences %s", name, audience_ids
+        )
+        payload = {
+            "name": name,
+            "audience_ids": audience_ids,
+            "daily_budget": budget,
+        }
+        headers = {"Authorization": f"Bearer {self.facebook_token}"}
+        url = "https://graph.facebook.com/v17.0/campaigns"
+
+        try:
+            resp = requests.post(url, json=payload, headers=headers, timeout=10)
+            resp.raise_for_status()
+            data = resp.json()
+            campaign_id = data.get("id")
+            status = data.get("status", "created")
+            return {
+                "platform": "facebook",
+                "campaign_id": campaign_id,
+                "status": status,
+                "message": None,
+            }
+        except requests.RequestException as exc:
+            logger.error("Facebook campaign creation failed: %s", exc)
+            return {
+                "platform": "facebook",
+                "campaign_id": None,
+                "status": "error",
+                "message": str(exc),
+            }
+
+    def create_google_campaign(
+        self, name: str, keywords: list, budget: int
+    ) -> Dict[str, Optional[Any]]:
+        """Create a basic Google Ads campaign.
+
+        Parameters
+        ----------
+        name:
+            Name for the new campaign.
+        keywords:
+            List of keywords to target.
+        budget:
+            Daily budget in micros.
+
+        Returns
+        -------
+        dict
+            ``{"platform": "google", "campaign_id": str | None, "status": str, "message": str | None}``
+        """
+
+        logger.info(
+            "Creating Google Ads campaign %s on keywords %s", name, keywords
+        )
+        payload = {"name": name, "keywords": keywords, "daily_budget": budget}
+        params = {"key": self.google_key}
+        url = "https://googleads.googleapis.com/v14/campaigns"
+
+        try:
+            resp = requests.post(url, json=payload, params=params, timeout=10)
+            resp.raise_for_status()
+            data = resp.json()
+            campaign_id = data.get("id")
+            status = data.get("status", "created")
+            return {
+                "platform": "google",
+                "campaign_id": campaign_id,
+                "status": status,
+                "message": None,
+            }
+        except requests.RequestException as exc:
+            logger.error("Google Ads campaign creation failed: %s", exc)
+            return {
+                "platform": "google",
+                "campaign_id": None,
+                "status": "error",
+                "message": str(exc),
+            }

--- a/tests/test_ad_tool.py
+++ b/tests/test_ad_tool.py
@@ -1,0 +1,83 @@
+import sys
+import types
+
+sys.modules.setdefault(
+    "requests",
+    types.SimpleNamespace(
+        post=lambda *a, **k: types.SimpleNamespace(
+            ok=True, json=lambda: {}, raise_for_status=lambda: None
+        ),
+        HTTPError=Exception,
+        RequestException=Exception,
+    ),
+)
+
+import requests
+from src.tools.ad_tool import AdTool
+
+class DummyResponse:
+    def __init__(self, data, exc=None):
+        self._data = data
+        self._exc = exc
+    def json(self):
+        return self._data
+    def raise_for_status(self):
+        if self._exc:
+            raise self._exc
+
+
+def test_create_facebook_campaign_success(monkeypatch):
+    def fake_post(url, json=None, headers=None, timeout=10):
+        return DummyResponse({"id": "fb123", "status": "CREATED"})
+
+    monkeypatch.setattr("src.tools.ad_tool.requests.post", fake_post)
+    tool = AdTool()
+    result = tool.create_facebook_campaign("Test", [1, 2], 100)
+    assert result == {
+        "platform": "facebook",
+        "campaign_id": "fb123",
+        "status": "CREATED",
+        "message": None,
+    }
+
+
+def test_create_facebook_campaign_error(monkeypatch):
+    def fake_post(url, json=None, headers=None, timeout=10):
+        return DummyResponse({}, exc=requests.HTTPError("bad"))
+
+    monkeypatch.setattr("src.tools.ad_tool.requests.post", fake_post)
+    tool = AdTool()
+    result = tool.create_facebook_campaign("Oops", [], 50)
+    assert result["platform"] == "facebook"
+    assert result["campaign_id"] is None
+    assert result["status"] == "error"
+    assert "bad" in result["message"]
+
+
+def test_create_google_campaign_success(monkeypatch):
+    def fake_post(url, json=None, params=None, timeout=10):
+        return DummyResponse({"id": "ga123", "status": "CREATED"})
+
+    monkeypatch.setattr("src.tools.ad_tool.requests.post", fake_post)
+    tool = AdTool()
+    result = tool.create_google_campaign("MyCamp", ["kw"], 200)
+    assert result == {
+        "platform": "google",
+        "campaign_id": "ga123",
+        "status": "CREATED",
+        "message": None,
+    }
+
+
+def test_create_google_campaign_error(monkeypatch):
+    def fake_post(url, json=None, params=None, timeout=10):
+        return DummyResponse({}, exc=requests.HTTPError("fail"))
+
+    monkeypatch.setattr("src.tools.ad_tool.requests.post", fake_post)
+    tool = AdTool()
+    result = tool.create_google_campaign("Bad", [], 10)
+    assert result["platform"] == "google"
+    assert result["campaign_id"] is None
+    assert result["status"] == "error"
+    assert "fail" in result["message"]
+


### PR DESCRIPTION
## Summary
- flesh out Facebook and Google campaign creation logic
- document ad platform credentials in README and environment docs
- add tests for AdTool helper methods

## Testing
- `pytest -q`
- `pytest tests/test_ad_tool.py -q`

------
