### PR TITLE
Add dashboard frontend app

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,23 @@ you design workflows composed of agent and tool nodes. The editor persists the
 graph by POSTing it to `/workflows` where the backend stores the definition for
 execution. The JSON format is described in [`docs/workflow_schema.json`](docs/workflow_schema.json).
 
+## 📊 Dashboard
+
+`frontend/dashboard` contains a small React + Bootstrap app for submitting events
+to the backend and tracking team status. It posts to `/teams/<name>/event` and
+polls `/teams/<name>/status`.
+
+### Development
+
+```bash
+cd frontend
+npm install
+npm run dev:dashboard
+```
+
+Run the tests with `npm test`. Building the project outputs both the editor and
+dashboard into `dist/` using the shared `vite.config.js`.
+
 ---
 
 This project is released under the [MIT License](LICENSE).

--- a/frontend/dashboard/__tests__/EventForm.test.jsx
+++ b/frontend/dashboard/__tests__/EventForm.test.jsx
@@ -1,0 +1,31 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import EventForm from '../src/components/EventForm';
+import { vi } from 'vitest';
+
+vi.stubGlobal('fetch', vi.fn());
+
+describe('EventForm', () => {
+  afterEach(() => {
+    fetch.mockClear();
+  });
+
+  it('posts event to the backend', async () => {
+    fetch.mockResolvedValue({ json: () => Promise.resolve({ result: 'ok' }) });
+    const onResult = vi.fn();
+    render(
+      <EventForm
+        team="sales"
+        setTeam={() => {}}
+        apiKey="secret"
+        setApiKey={() => {}}
+        onResult={onResult}
+      />
+    );
+    fireEvent.change(screen.getByLabelText(/Event Type/i), { target: { value: 'lead' } });
+    fireEvent.change(screen.getByLabelText(/Payload/i), { target: { value: '{}' } });
+    fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+    expect(fetch.mock.calls[0][0]).toBe('/teams/sales/event');
+    expect(onResult).toHaveBeenCalled();
+  });
+});

--- a/frontend/dashboard/__tests__/StatusViewer.test.jsx
+++ b/frontend/dashboard/__tests__/StatusViewer.test.jsx
@@ -1,0 +1,21 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import StatusViewer from '../src/components/StatusViewer';
+import { vi } from 'vitest';
+
+vi.stubGlobal('fetch', vi.fn());
+
+describe('StatusViewer', () => {
+  afterEach(() => {
+    fetch.mockClear();
+  });
+
+  it('polls status endpoint periodically', async () => {
+    vi.useFakeTimers();
+    fetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ status: 'done' }) });
+    render(<StatusViewer team="sales" apiKey="secret" interval={1000} />);
+    await vi.advanceTimersByTimeAsync(1000);
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+    expect(fetch.mock.calls[0][0]).toBe('/teams/sales/status');
+    vi.useRealTimers();
+  });
+});

--- a/frontend/dashboard/index.html
+++ b/frontend/dashboard/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Team Dashboard</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/dashboard/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/dashboard/src/App.jsx
+++ b/frontend/dashboard/src/App.jsx
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+import EventForm from './components/EventForm';
+import StatusViewer from './components/StatusViewer';
+import 'bootstrap/dist/css/bootstrap.min.css';
+
+export default function App() {
+  const [team, setTeam] = useState('');
+  const [apiKey, setApiKey] = useState('');
+  const [result, setResult] = useState(null);
+
+  return (
+    <div className="container py-4">
+      <h1 className="mb-4">Team Dashboard</h1>
+      <EventForm
+        team={team}
+        setTeam={setTeam}
+        apiKey={apiKey}
+        setApiKey={setApiKey}
+        onResult={(data) => setResult(JSON.stringify(data, null, 2))}
+      />
+      <StatusViewer team={team} apiKey={apiKey} />
+      {result && (
+        <div className="mt-4">
+          <h5>Result</h5>
+          <pre data-testid="result">{result}</pre>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/dashboard/src/components/EventForm.jsx
+++ b/frontend/dashboard/src/components/EventForm.jsx
@@ -1,0 +1,88 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { Form, Button, Alert } from 'react-bootstrap';
+
+/**
+ * Form for submitting events to a team via the backend API.
+ * The parent component must hold the ``team`` and ``apiKey`` state so that
+ * ``StatusViewer`` can poll the same team.
+ */
+function EventForm({ team, setTeam, apiKey, setApiKey, onResult }) {
+  const [eventType, setEventType] = useState('');
+  const [payload, setPayload] = useState('{}');
+  const [error, setError] = useState(null);
+
+  const submit = async (e) => {
+    e.preventDefault();
+    try {
+      const response = await fetch(`/teams/${team}/event`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-API-Key': apiKey,
+        },
+        body: JSON.stringify({ type: eventType, payload: JSON.parse(payload) }),
+      });
+      const data = await response.json();
+      onResult(data);
+      setError(null);
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <Form onSubmit={submit} data-testid="event-form">
+      {error && (
+        <Alert variant="danger" data-testid="error">
+          {error}
+        </Alert>
+      )}
+      <Form.Group className="mb-3">
+        <Form.Label>Team Name</Form.Label>
+        <Form.Control
+          value={team}
+          onChange={(e) => setTeam(e.target.value)}
+          required
+        />
+      </Form.Group>
+      <Form.Group className="mb-3">
+        <Form.Label>API Key</Form.Label>
+        <Form.Control
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+        />
+      </Form.Group>
+      <Form.Group className="mb-3">
+        <Form.Label>Event Type</Form.Label>
+        <Form.Control
+          value={eventType}
+          onChange={(e) => setEventType(e.target.value)}
+          required
+        />
+      </Form.Group>
+      <Form.Group className="mb-3">
+        <Form.Label>Payload (JSON)</Form.Label>
+        <Form.Control
+          as="textarea"
+          rows={3}
+          value={payload}
+          onChange={(e) => setPayload(e.target.value)}
+        />
+      </Form.Group>
+      <Button variant="primary" type="submit">
+        Submit
+      </Button>
+    </Form>
+  );
+}
+
+EventForm.propTypes = {
+  team: PropTypes.string.isRequired,
+  setTeam: PropTypes.func.isRequired,
+  apiKey: PropTypes.string,
+  setApiKey: PropTypes.func.isRequired,
+  onResult: PropTypes.func.isRequired,
+};
+
+export default EventForm;

--- a/frontend/dashboard/src/components/StatusViewer.jsx
+++ b/frontend/dashboard/src/components/StatusViewer.jsx
@@ -1,0 +1,60 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Polls ``/teams/{team}/status`` on a fixed interval and displays the result.
+ * If the API supported Server-Sent Events or websockets, this component could
+ * subscribe instead of polling.
+ */
+function StatusViewer({ team, apiKey, interval = 5000 }) {
+  const [status, setStatus] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!team) return undefined;
+    let active = true;
+
+    const fetchStatus = async () => {
+      try {
+        const res = await fetch(`/teams/${team}/status`, {
+          headers: { 'X-API-Key': apiKey },
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json();
+        if (active) {
+          setStatus(data.status);
+          setError(null);
+        }
+      } catch (err) {
+        if (active) setError(err.message);
+      }
+    };
+
+    fetchStatus();
+    const id = setInterval(fetchStatus, interval);
+    return () => {
+      active = false;
+      clearInterval(id);
+    };
+  }, [team, apiKey, interval]);
+
+  if (!team) return null;
+  return (
+    <div className="mt-4" data-testid="status-viewer">
+      <h5>Current Status</h5>
+      {error ? (
+        <p className="text-danger" data-testid="status-error">{error}</p>
+      ) : (
+        <p data-testid="status-text">{status || 'Loading...'}</p>
+      )}
+    </div>
+  );
+}
+
+StatusViewer.propTypes = {
+  team: PropTypes.string,
+  apiKey: PropTypes.string,
+  interval: PropTypes.number,
+};
+
+export default StatusViewer;

--- a/frontend/dashboard/src/main.jsx
+++ b/frontend/dashboard/src/main.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const root = createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,16 +4,24 @@
   "version": "0.1.0",
   "scripts": {
     "dev": "vite",
+    "dev:dashboard": "vite --open /dashboard/",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "reactflow": "^11.0.0"
+    "reactflow": "^11.0.0",
+    "react-bootstrap": "^2.9.0",
+    "bootstrap": "^5.3.1",
+    "prop-types": "^15.8.1"
   },
   "devDependencies": {
     "vite": "^4.0.0",
-    "@vitejs/plugin-react": "^4.0.0"
+    "@vitejs/plugin-react": "^4.0.0",
+    "vitest": "^0.34.6",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.1.4"
   }
 }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,9 +1,22 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
 
 export default defineConfig({
   plugins: [react()],
   server: {
     port: 5173
+  },
+  build: {
+    rollupOptions: {
+      input: {
+        editor: resolve(__dirname, 'index.html'),
+        dashboard: resolve(__dirname, 'dashboard/index.html')
+      }
+    }
+  },
+  test: {
+    globals: true,
+    environment: 'jsdom'
   }
 });


### PR DESCRIPTION
## Summary
- create dashboard React app for sending events and polling status
- integrate dashboard build into vite config
- document dashboard usage in README
- add vitest test setup and tests for dashboard components
- update frontend dependencies

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: vitest not found)*
- `pytest -q` *(fails: AttributeError in revops tests)*

------
