### PR TITLE
Read API key from env in editor

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_KEY=

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -12,3 +12,27 @@ npm run dev
 
 The application persists workflows by sending them to the backend via the
 `/workflows` API endpoint.
+
+## Configuration
+
+The editor requires an API key when communicating with the backend service.
+Create an `.env` file in this directory and define `VITE_API_KEY`:
+
+```bash
+cp .env.example .env
+echo "VITE_API_KEY=mysecret" >> .env
+```
+
+When running `npm run dev` or building the project with `vite`, the value of
+`VITE_API_KEY` is injected and included as the `X-API-Key` header on every
+workflow save request. For production deployments you may also inject a
+runtime configuration object named `window.APP_CONFIG` before loading the
+bundle:
+
+```html
+<script>
+  window.APP_CONFIG = { apiKey: 'mysecret' };
+</script>
+```
+
+This fallback enables dynamic key assignment without rebuilding the frontend.

--- a/frontend/__tests__/App.test.jsx
+++ b/frontend/__tests__/App.test.jsx
@@ -1,0 +1,21 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import App from '../src/App';
+
+vi.stubGlobal('fetch', vi.fn());
+
+vi.stubEnv('VITE_API_KEY', 'test-key');
+
+describe('App', () => {
+  afterEach(() => {
+    fetch.mockClear();
+  });
+
+  it('sends API key from environment when saving', async () => {
+    render(<App />);
+    fireEvent.click(screen.getByText(/save/i));
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+    const options = fetch.mock.calls[0][1];
+    expect(options.headers['X-API-Key']).toBe('test-key');
+  });
+});

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import ReactFlow, { Background, Controls, addEdge } from 'reactflow';
 import 'reactflow/dist/style.css';
+import { getApiKey } from './config';
 
 export default function App() {
   const [nodes, setNodes] = useState([]);
@@ -11,12 +12,25 @@ export default function App() {
   const save = async () => {
     const workflow = {
       name: 'workflow',
-      nodes: nodes.map((n) => ({ id: n.id, type: n.type || 'agent', label: n.data?.label || n.id })),
-      edges: edges.map((e) => ({ source: e.source, target: e.target, label: e.label })),
+      nodes: nodes.map((n) => ({
+        id: n.id,
+        type: n.type || 'agent',
+        label: n.data?.label || n.id,
+      })),
+      edges: edges.map((e) => ({
+        source: e.source,
+        target: e.target,
+        label: e.label,
+      })),
     };
+
+    const headers = { 'Content-Type': 'application/json' };
+    const apiKey = getApiKey();
+    if (apiKey) headers['X-API-Key'] = apiKey;
+
     await fetch('/workflows', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'X-API-Key': 'secret' },
+      headers,
       body: JSON.stringify(workflow),
     });
   };

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,0 +1,15 @@
+export function getApiKey() {
+  // Prioritise environment variables injected at build time via Vite.
+  const envKey = import.meta?.env?.VITE_API_KEY;
+  if (envKey && envKey !== 'undefined') {
+    return envKey;
+  }
+
+  // Fallback to runtime configuration (e.g. window.APP_CONFIG.apiKey)
+  if (typeof window !== 'undefined' && window.APP_CONFIG?.apiKey) {
+    return window.APP_CONFIG.apiKey;
+  }
+
+  return '';
+}
+

--- a/src/crm_connector.py
+++ b/src/crm_connector.py
@@ -51,8 +51,10 @@ def fetch_deals(tenant_id: str) -> List[Deal]:
     Raises ``RuntimeError`` if the optional ``requests`` dependency is missing.
     """
 
-    if not requests:  # pragma: no cover - optional dependency
-        logger.warning("requests package is not installed; returning empty list")
+    if not getattr(requests, "get", None):  # pragma: no cover - optional dep
+        logger.warning(
+            "requests package is not installed or lacks 'get'; returning empty list"
+        )
         return []
 
     url = f"{settings.CRM_API_URL}/deals"


### PR DESCRIPTION
## Summary
- pull API key from Vite env or runtime config in the workflow editor
- document VITE_API_KEY usage in the frontend README
- provide `.env.example` for easy setup
- add tests for env-based API key
- harden optional requests dependency handling

## Testing
- `pytest -q`
- `npm --prefix frontend test` *(fails: vitest not found)*

------
