### PR TITLE
Implement SSE streaming for team status

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,21 @@ Query recent activity:
 curl -H "X-API-Key: mysecret" http://localhost:8000/activity?limit=20
 ```
 
+Stream live updates using Server-Sent Events:
+
+```bash
+curl -H "X-API-Key: mysecret" http://localhost:8000/teams/sales/stream --no-buffer
+```
+
+Clients receive ``status`` and ``activity`` events in real time. The dashboard
+subscribes via ``EventSource``:
+
+```javascript
+const src = new EventSource('/teams/sales/stream?api_key=mysecret');
+src.addEventListener('status', (e) => console.log('status', e.data));
+src.addEventListener('activity', (e) => console.log('activity', e.data));
+```
+
 ### 📈 Activity Logs
 
 Every handled event is appended to a JSON Lines file. Each entry records the
@@ -474,7 +489,8 @@ execution. The JSON format is described in [`docs/workflow_schema.json`](docs/wo
 
 `frontend/dashboard` contains a small React + Bootstrap app for submitting events
 to the backend and tracking team status. It posts to `/teams/<name>/event` and
-polls `/teams/<name>/status`.
+either polls `/teams/<name>/status` or connects to `/teams/<name>/stream` for
+live updates.
 
 ### Development
 
@@ -485,7 +501,8 @@ npm run dev:dashboard
 ```
 
 Run the tests with `npm test`. Building the project outputs both the editor and
-dashboard into `dist/` using the shared `vite.config.js`.
+dashboard into `dist/` using the shared `vite.config.js`. The dashboard's
+"Live Stream" section showcases the `/teams/<name>/stream` endpoint in action.
 
 ---
 

--- a/frontend/dashboard/__tests__/StreamViewer.test.jsx
+++ b/frontend/dashboard/__tests__/StreamViewer.test.jsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import StreamViewer from '../src/components/StreamViewer';
+import { vi } from 'vitest';
+
+let lastInstance;
+class MockEventSource {
+  constructor(url) {
+    this.url = url;
+    this.listeners = {};
+    lastInstance = this;
+  }
+  addEventListener(type, cb) {
+    this.listeners[type] = cb;
+  }
+  close() {
+    this.closed = true;
+  }
+  emit(type, data) {
+    if (this.listeners[type]) this.listeners[type]({ data });
+  }
+}
+
+vi.stubGlobal('EventSource', MockEventSource);
+
+describe('StreamViewer', () => {
+  it('connects to SSE endpoint and renders messages', () => {
+    render(<StreamViewer team="sales" apiKey="secret" />);
+    expect(lastInstance.url).toBe('/teams/sales/stream?api_key=secret');
+    lastInstance.emit('status', 'running');
+    expect(screen.getByTestId('stream-data').textContent).toMatch('running');
+  });
+});

--- a/frontend/dashboard/src/App.jsx
+++ b/frontend/dashboard/src/App.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import EventForm from './components/EventForm';
 import StatusViewer from './components/StatusViewer';
+import StreamViewer from './components/StreamViewer';
 import 'bootstrap/dist/css/bootstrap.min.css';
 
 export default function App() {
@@ -19,6 +20,7 @@ export default function App() {
         onResult={(data) => setResult(JSON.stringify(data, null, 2))}
       />
       <StatusViewer team={team} apiKey={apiKey} />
+      <StreamViewer team={team} apiKey={apiKey} />
       {result && (
         <div className="mt-4">
           <h5>Result</h5>

--- a/frontend/dashboard/src/components/StreamViewer.jsx
+++ b/frontend/dashboard/src/components/StreamViewer.jsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Subscribe to the `/teams/{team}/stream` SSE endpoint and display messages.
+ */
+function StreamViewer({ team, apiKey }) {
+  const [messages, setMessages] = useState([]);
+
+  useEffect(() => {
+    if (!team) return undefined;
+    const url = `/teams/${team}/stream?api_key=${encodeURIComponent(apiKey || '')}`;
+    const source = new EventSource(url);
+    const handleStatus = (e) => setMessages((m) => [...m, `status: ${e.data}`]);
+    const handleActivity = (e) => setMessages((m) => [...m, `activity: ${e.data}`]);
+    source.addEventListener('status', handleStatus);
+    source.addEventListener('activity', handleActivity);
+    return () => source.close();
+  }, [team, apiKey]);
+
+  if (!team) return null;
+  return (
+    <div className="mt-4" data-testid="stream-viewer">
+      <h5>Live Stream</h5>
+      <pre data-testid="stream-data">{messages.join('\n')}</pre>
+    </div>
+  );
+}
+
+StreamViewer.propTypes = {
+  team: PropTypes.string,
+  apiKey: PropTypes.string,
+};
+
+export default StreamViewer;

--- a/src/api.py
+++ b/src/api.py
@@ -20,8 +20,10 @@ if __package__ in {None, ""}:  # pragma: no cover - safe for direct execution
 
 from typing import Any, Dict, List, Literal
 import json
+import asyncio
 
-from fastapi import Depends, FastAPI, Header, HTTPException
+from fastapi import Depends, FastAPI, Header, HTTPException, Request
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
 
@@ -78,9 +80,12 @@ def create_app(orchestrator: SolutionOrchestrator | None = None) -> FastAPI:
     orch = orchestrator or SolutionOrchestrator({})
     workflow_dir = Path(__file__).resolve().parent / "workflows" / "saved"
 
-    async def _auth(x_api_key: str = Header(...)) -> None:
+    async def _auth(request: Request, x_api_key: str | None = Header(None)) -> None:
+        """Validate API key from header or ``api_key`` query parameter."""
+
         required = settings.API_AUTH_KEY
-        if required and x_api_key != required:
+        supplied = x_api_key or request.query_params.get("api_key")
+        if required and supplied != required:
             raise HTTPException(status_code=401, detail="invalid api key")
 
     @app.post("/teams/{name}/event")
@@ -99,6 +104,31 @@ def create_app(orchestrator: SolutionOrchestrator | None = None) -> FastAPI:
         if status is None:
             raise HTTPException(status_code=404, detail="unknown team")
         return {"team": name, "status": status}
+
+    @app.get("/teams/{name}/stream")
+    async def stream(name: str, request: Request, _=Depends(_auth)):
+        """Server-Sent Events stream of status and activity messages."""
+
+        queue = orch.subscribe(name)
+
+        async def event_generator():
+            try:
+                current = orch.get_status(name)
+                if current is not None:
+                    payload = json.dumps({"status": current})
+                    yield f"event: status\ndata: {payload}\n\n"
+                while True:
+                    if await request.is_disconnected():
+                        break
+                    try:
+                        msg = await asyncio.wait_for(queue.get(), 1.0)
+                    except asyncio.TimeoutError:
+                        continue
+                    yield f"event: {msg['type']}\ndata: {json.dumps(msg)}\n\n"
+            finally:
+                orch.unsubscribe(name, queue)
+
+        return StreamingResponse(event_generator(), media_type="text/event-stream")
 
     @app.get("/activity")
     def get_activity(limit: int = 10, _=Depends(_auth)) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- add server-sent events endpoint `/teams/{name}/stream`
- broadcast orchestrator status/activity to connected streams
- expose a `StreamViewer` component in the dashboard
- update docs with streaming usage example
- test React component

## Testing
- `pytest -q`
- `npm test --silent` *(fails: vitest not found)*

------
