### PR TITLE
Improve dashboard docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,6 +500,41 @@ npm install
 npm run dev:dashboard
 ```
 
+### Running the Dashboard
+
+Start the HTTP API with an authentication key and at least one team configuration:
+
+```bash
+API_AUTH_KEY=mysecret python -m src.api sales=src/teams/sales_team_full.json
+```
+
+Create a `.env` file inside `frontend/dashboard` so the React app can use the same key when
+communicating with the backend:
+
+```bash
+cd frontend/dashboard
+cp ../.env.example .env
+echo "VITE_API_KEY=mysecret" >> .env
+npm run dev:dashboard
+```
+
+Open the browser at [http://localhost:5173/dashboard](http://localhost:5173/dashboard). Fill in the
+team name (e.g. `sales`), choose an event type like `lead_capture` and enter the event payload in JSON
+format. Submitting the form posts the event to `/teams/<name>/event` and refreshes the status panel.
+
+The screenshot below demonstrates a typical lead submission form with the team name,
+event type, and JSON payload fields.
+
+![Lead submission form](docs/images/dashboard_lead_submission.svg)
+_Example placeholder screenshot_
+
+The dashboard polls `/teams/<name>/status` every few seconds and shows the most recent update:
+
+![Status display](docs/images/dashboard_status_display.svg)
+_Example placeholder screenshot_
+
+The "Live Stream" section demonstrates real-time updates from `/teams/<name>/stream`.
+
 Run the tests with `npm test`. Building the project outputs both the editor and
 dashboard into `dist/` using the shared `vite.config.js`. The dashboard's
 "Live Stream" section showcases the `/teams/<name>/stream` endpoint in action.

--- a/docs/images/dashboard_lead_submission.svg
+++ b/docs/images/dashboard_lead_submission.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="300">
+  <rect width="100%" height="100%" fill="#ffffff"/>
+  <rect x="20" y="20" width="560" height="260" fill="#f8f9fa" stroke="#ced4da"/>
+  <text x="300" y="50" font-family="Arial, sans-serif" font-size="18" fill="#343a40" text-anchor="middle">Lead Submission</text>
+  <rect x="40" y="70" width="200" height="26" fill="#ffffff" stroke="#6c757d"/>
+  <text x="50" y="87" font-family="Arial, sans-serif" font-size="12" fill="#6c757d">Team: sales</text>
+  <rect x="40" y="110" width="200" height="26" fill="#ffffff" stroke="#6c757d"/>
+  <text x="50" y="127" font-family="Arial, sans-serif" font-size="12" fill="#6c757d">Event: lead_capture</text>
+  <rect x="40" y="150" width="520" height="60" fill="#ffffff" stroke="#6c757d"/>
+  <text x="50" y="170" font-family="Arial, sans-serif" font-size="12" fill="#6c757d">{"email": "alice@example.com"}</text>
+  <rect x="40" y="220" width="80" height="28" fill="#0d6efd" stroke="#0a58ca"/>
+  <text x="80" y="239" font-family="Arial, sans-serif" font-size="12" fill="#ffffff" text-anchor="middle">Submit</text>
+</svg>

--- a/docs/images/dashboard_status_display.svg
+++ b/docs/images/dashboard_status_display.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="300">
+  <rect width="100%" height="100%" fill="#ffffff"/>
+  <rect x="20" y="20" width="560" height="260" fill="#f8f9fa" stroke="#ced4da"/>
+  <text x="300" y="50" font-family="Arial, sans-serif" font-size="18" fill="#343a40" text-anchor="middle">Status Panel</text>
+  <rect x="40" y="80" width="520" height="30" fill="#e9ecef" stroke="#adb5bd"/>
+  <text x="50" y="100" font-family="Arial, sans-serif" font-size="12" fill="#495057">sales: lead captured</text>
+  <rect x="40" y="120" width="520" height="30" fill="#e9ecef" stroke="#adb5bd"/>
+  <text x="50" y="140" font-family="Arial, sans-serif" font-size="12" fill="#495057">operations: shipping scheduled</text>
+  <rect x="40" y="160" width="520" height="30" fill="#e9ecef" stroke="#adb5bd"/>
+  <text x="50" y="180" font-family="Arial, sans-serif" font-size="12" fill="#495057">marketing: campaign launched</text>
+</svg>


### PR DESCRIPTION
## Summary
- refine README instructions for running the dashboard
- fix path to dashboard .env file
- enhance dashboard SVG placeholders so examples are visible

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6854931d9c30832b90c955d46fd018c0