### PR TITLE
Add graph workflow engine

### DIFF
--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -44,3 +44,22 @@ For more complex flows you can describe nodes and edges explicitly. The
 [`workflow_schema.json`](workflow_schema.json). Each node represents an `agent`
 or `tool` and edges model the execution order. Persist the file via the `/workflows`
 endpoint and load it later with `GraphWorkflowDefinition.from_file()`.
+
+### Executing Graph Workflows
+
+`GraphWorkflowEngine` walks the graph in topological order and dispatches each
+node through `SolutionOrchestrator`. A node's ``config`` must include a
+``team`` name and an ``event`` dictionary which are forwarded to
+``SolutionOrchestrator.handle_event_sync``.
+
+```python
+from src.solution_orchestrator import SolutionOrchestrator
+from src.workflows.graph import GraphWorkflowDefinition
+
+orch = SolutionOrchestrator({"A": "team_a.json"})
+wf = GraphWorkflowDefinition.from_file("workflows/my_flow.json")
+orch.execute_workflow(wf)
+```
+
+``execute_workflow`` returns a dictionary containing the orchestrator results
+for every node.

--- a/src/solution_orchestrator.py
+++ b/src/solution_orchestrator.py
@@ -11,6 +11,7 @@ from .utils import ActivityLogger
 from . import db
 
 from .agents.planner_agent import PlannerAgent
+from .workflows.graph import GraphWorkflowDefinition, GraphWorkflowEngine
 
 from .team_orchestrator import TeamOrchestrator
 
@@ -129,3 +130,22 @@ class SolutionOrchestrator:
         if not self.planner:
             raise RuntimeError("Planner is not configured")
         return self.planner.run({"goal": goal})
+
+    def execute_workflow(
+        self, workflow: str | Path | GraphWorkflowDefinition
+    ) -> Dict[str, Any]:
+        """Execute a graph workflow definition.
+
+        ``workflow`` may be a path to a JSON file or a pre-loaded
+        :class:`GraphWorkflowDefinition` instance. Each node ``config`` must
+        include ``team`` and ``event`` fields which are forwarded to
+        :meth:`handle_event_sync`.
+        """
+
+        if isinstance(workflow, (str, Path)):
+            definition = GraphWorkflowDefinition.from_file(workflow)
+        else:
+            definition = workflow
+
+        engine = GraphWorkflowEngine(definition)
+        return engine.run(self)

--- a/tests/test_graph_workflow_engine.py
+++ b/tests/test_graph_workflow_engine.py
@@ -1,0 +1,134 @@
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from src.solution_orchestrator import SolutionOrchestrator
+from src.agents.base_agent import BaseAgent
+from src.workflows.graph import (
+    GraphWorkflowDefinition,
+    NodeDefinition,
+    EdgeDefinition,
+)
+
+
+class DummyAgentA(BaseAgent):
+    def run(self, payload):
+        return {"handled_by": "A", **payload}
+
+
+class DummyAgentB(BaseAgent):
+    def run(self, payload):
+        return {"handled_by": "B", **payload}
+
+
+def _write_team(tmp_path: Path, agent_name: str) -> Path:
+    config = {
+        "responsibilities": [agent_name],
+        "config": {"participants": [{"config": {"name": agent_name}}]},
+    }
+    path = tmp_path / f"{agent_name}.json"
+    path.write_text(json.dumps(config))
+    return path
+
+
+def _register_agents():
+    mod_a = types.ModuleType("src.agents.dummy_agent_a")
+    mod_a.DummyAgentA = DummyAgentA
+    sys.modules["src.agents.dummy_agent_a"] = mod_a
+
+    mod_b = types.ModuleType("src.agents.dummy_agent_b")
+    mod_b.DummyAgentB = DummyAgentB
+    sys.modules["src.agents.dummy_agent_b"] = mod_b
+
+
+def test_linear_graph_execution(tmp_path):
+    _register_agents()
+    team_a = _write_team(tmp_path, "dummy_agent_a")
+    team_b = _write_team(tmp_path, "dummy_agent_b")
+
+    orch = SolutionOrchestrator({"A": str(team_a), "B": str(team_b)})
+
+    wf = GraphWorkflowDefinition(
+        name="linear",
+        nodes=[
+            NodeDefinition(
+                id="a",
+                type="agent",
+                label="A",
+                config={
+                    "team": "A",
+                    "event": {"type": "dummy_agent_a", "payload": {"foo": 1}},
+                },
+            ),
+            NodeDefinition(
+                id="b",
+                type="agent",
+                label="B",
+                config={
+                    "team": "B",
+                    "event": {"type": "dummy_agent_b", "payload": {"bar": 2}},
+                },
+            ),
+        ],
+        edges=[EdgeDefinition(source="a", target="b")],
+    )
+
+    result = orch.execute_workflow(wf)
+
+    assert result["status"] == "complete"
+    assert [r["team"] for r in result["results"]] == ["A", "B"]
+    assert result["results"][0]["result"]["result"]["handled_by"] == "A"
+    assert result["results"][1]["result"]["result"]["handled_by"] == "B"
+
+
+def test_branching_graph_execution(tmp_path):
+    _register_agents()
+    team_a = _write_team(tmp_path, "dummy_agent_a")
+    team_b = _write_team(tmp_path, "dummy_agent_b")
+
+    orch = SolutionOrchestrator({"A": str(team_a), "B": str(team_b)})
+
+    wf = GraphWorkflowDefinition(
+        name="branching",
+        nodes=[
+            NodeDefinition(
+                id="start",
+                type="agent",
+                label="Start",
+                config={"team": "A", "event": {"type": "dummy_agent_a", "payload": {}}},
+            ),
+            NodeDefinition(
+                id="a",
+                type="agent",
+                label="A",
+                config={
+                    "team": "A",
+                    "event": {"type": "dummy_agent_a", "payload": {"a": 1}},
+                },
+            ),
+            NodeDefinition(
+                id="b",
+                type="agent",
+                label="B",
+                config={
+                    "team": "B",
+                    "event": {"type": "dummy_agent_b", "payload": {"b": 2}},
+                },
+            ),
+        ],
+        edges=[
+            EdgeDefinition(source="start", target="a"),
+            EdgeDefinition(source="start", target="b"),
+        ],
+    )
+
+    result = orch.execute_workflow(wf)
+
+    assert result["status"] == "complete"
+    assert len(result["results"]) == 3
+    assert result["results"][0]["node"] == "start"
+    teams = {r["team"] for r in result["results"]}
+    assert teams == {"A", "B"}


### PR DESCRIPTION
## Summary
- add `GraphWorkflowEngine` for executing graph definitions
- wire SolutionOrchestrator to run workflows
- test linear and branching graph flows
- document new graph workflow execution model

## Testing
- `pytest -q`


------
