### PR TITLE
Add team schema validation and CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,9 @@ brookside-cli send --team sales --event '{"type": "lead_capture", "payload": {"e
 # view latest statuses
 brookside-cli status
 
+# validate a team configuration
+brookside-cli validate-team src/teams/sales_team_full.json
+
 # map a natural language task to a workflow template
 brookside-cli assist "handle new inventory"
 # => {"template": "src/teams/inventory_management_team.json"}
@@ -430,6 +433,7 @@ also included:
 * `dev_assist.py` – generate boilerplate modules and matching tests.
 * `debugger_agent.py` – listen for `*.Error` events and propose patches.
 * `brookside-cli assist` – convert plain language tasks into workflow templates.
+* `brookside-cli validate-team` – verify a team JSON file against the schema.
 * `qa_agent.py` – run scripted conversations against `SupportAgent` and emit QA
   reports.
 * `review_agent.py` – automatically approve or reject drafts published on the event bus.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -116,7 +116,7 @@ At this point all AutoGen agents are live and waiting for events. Teams remain a
 
 ## AutoGen Agents and Providers
 
-Team JSON files under `src/teams/` describe `RoundRobinGroupChat` configurations.  Each agent entry specifies a `provider` such as `src.agents.roles.AssistantAgent` or `autogen.models.openai.OpenAIChatCompletionClient`.  When a team is loaded, these providers are instantiated and stitched together by AutoGen.
+Team JSON files under `src/teams/` describe `RoundRobinGroupChat` configurations.  Each agent entry specifies a `provider` such as `src.agents.roles.AssistantAgent` or `autogen.models.openai.OpenAIChatCompletionClient`.  When a team is loaded, these providers are instantiated and stitched together by AutoGen.  The full structure of a team file is defined in [`team_schema.json`](team_schema.json) and can be checked using `brookside-cli validate-team`.
 
 Each team file may optionally include a `responsibilities` array listing the
 agent names allowed to operate within that team.  When a team is loaded the

--- a/docs/team_schema.json
+++ b/docs/team_schema.json
@@ -1,0 +1,41 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Team Configuration",
+    "type": "object",
+    "required": ["provider", "config"],
+    "properties": {
+        "provider": {"type": "string"},
+        "component_type": {"type": "string"},
+        "version": {"type": "number"},
+        "component_version": {"type": "number"},
+        "description": {"type": "string"},
+        "label": {"type": "string"},
+        "responsibilities": {"type": "array", "items": {"type": "string"}},
+        "config": {
+            "type": "object",
+            "required": ["participants"],
+            "properties": {
+                "participants": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "required": ["config"],
+                        "properties": {
+                            "provider": {"type": "string"},
+                            "component_type": {"type": "string"},
+                            "config": {
+                                "type": "object",
+                                "required": ["name"],
+                                "properties": {
+                                    "name": {"type": "string"}
+                                }
+                            }
+                        }
+                    }
+                },
+                "tools": {"type": "array", "items": {"type": "object"}}
+            }
+        }
+    }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ fastapi>=0.110.0  # memory service server
 uvicorn>=0.22.0
 PyYAML>=6.0
 pyautogen>=0.2.16
+jsonschema>=4.18.0
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -163,6 +163,20 @@ def cmd_status(args: argparse.Namespace) -> None:
     print(json.dumps(resp))
 
 
+def cmd_validate_team(args: argparse.Namespace) -> None:
+    """Validate a team JSON file against ``team_schema.json``."""
+
+    from .team_orchestrator import validate_team_config
+
+    try:
+        data = json.loads(Path(args.path).read_text())
+        validate_team_config(data)
+    except Exception as exc:
+        print(json.dumps({"valid": False, "error": str(exc)}))
+    else:
+        print(json.dumps({"valid": True}))
+
+
 def _match_workflow(task: str) -> str | None:
     """Return the workflow template matching ``task`` if any."""
 
@@ -221,6 +235,12 @@ def build_parser() -> argparse.ArgumentParser:
     status_p.add_argument("--host", default=DEFAULT_HOST, help="Server address")
     status_p.add_argument("--port", type=int, default=DEFAULT_PORT, help="Server port")
     status_p.set_defaults(func=cmd_status)
+
+    validate_p = sub.add_parser(
+        "validate-team", help="Validate a team JSON configuration file"
+    )
+    validate_p.add_argument("path", help="Path to team JSON file")
+    validate_p.set_defaults(func=cmd_validate_team)
 
     return parser
 

--- a/src/jsonschema_stub.py
+++ b/src/jsonschema_stub.py
@@ -1,0 +1,42 @@
+"""Minimal fallback implementation of the jsonschema.validate API."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+class ValidationError(Exception):
+    """Exception raised when validation fails."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+
+def validate(instance: Any, schema: Dict[str, Any]) -> None:
+    """Very small subset of JSON Schema validation.
+
+    Only supports ``type`` checks for "object" and "array" and the ``required``
+    and ``properties`` keywords used by the team schema. The function raises
+    :class:`ValidationError` if the instance does not conform to the schema.
+    """
+
+    def _check(value: Any, sch: Dict[str, Any]) -> None:
+        t = sch.get("type")
+        if t == "object":
+            if not isinstance(value, dict):
+                raise ValidationError("expected object")
+            for req in sch.get("required", []):
+                if req not in value:
+                    raise ValidationError(f"'{req}' is required")
+            for key, subschema in sch.get("properties", {}).items():
+                if key in value:
+                    _check(value[key], subschema)
+        elif t == "array":
+            if not isinstance(value, list):
+                raise ValidationError("expected array")
+            for item in value:
+                if "items" in sch:
+                    _check(item, sch["items"])
+
+    _check(instance, schema)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -39,16 +39,26 @@ def _http_post(
         return err.code, err.read().decode()
 
 
-def _http_options(url: str, headers: dict[str, str] | None = None) -> tuple[int, str, str]:
+def _http_options(
+    url: str, headers: dict[str, str] | None = None
+) -> tuple[int, str, str]:
     base_headers = {"Access-Control-Request-Method": "POST"}
     if headers:
         base_headers.update(headers)
     req = urllib_request.Request(url, headers=base_headers, method="OPTIONS")
     try:
         with urllib_request.urlopen(req) as resp:
-            return resp.getcode(), resp.read().decode(), resp.headers.get("Access-Control-Allow-Origin", "")
+            return (
+                resp.getcode(),
+                resp.read().decode(),
+                resp.headers.get("Access-Control-Allow-Origin", ""),
+            )
     except urllib_request.HTTPError as err:  # type: ignore[attr-defined]
-        return err.code, err.read().decode(), err.headers.get("Access-Control-Allow-Origin", "")
+        return (
+            err.code,
+            err.read().decode(),
+            err.headers.get("Access-Control-Allow-Origin", ""),
+        )
 
 
 from src.agents.base_agent import BaseAgent
@@ -61,6 +71,7 @@ class EchoAgent(BaseAgent):
 
 def _write_team(tmp_path: Path) -> Path:
     cfg = {
+        "provider": "autogen.agentchat.teams.RoundRobinGroupChat",
         "responsibilities": ["echo_agent"],
         "config": {"participants": [{"config": {"name": "echo_agent"}}]},
     }

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -29,6 +29,7 @@ def _register_agent() -> None:
 
 def _write_team(tmp_path: Path) -> Path:
     cfg = {
+        "provider": "autogen.agentchat.teams.RoundRobinGroupChat",
         "responsibilities": ["echo_agent"],
         "config": {"participants": [{"config": {"name": "echo_agent"}}]},
     }

--- a/tests/test_graph_workflow_engine.py
+++ b/tests/test_graph_workflow_engine.py
@@ -26,6 +26,7 @@ class DummyAgentB(BaseAgent):
 
 def _write_team(tmp_path: Path, agent_name: str) -> Path:
     config = {
+        "provider": "autogen.agentchat.teams.RoundRobinGroupChat",
         "responsibilities": [agent_name],
         "config": {"participants": [{"config": {"name": agent_name}}]},
     }

--- a/tests/test_planner_agent.py
+++ b/tests/test_planner_agent.py
@@ -21,6 +21,7 @@ class DummyAgentB(BaseAgent):
 
 def _write_team(tmp_path: Path, agent_name: str) -> Path:
     cfg = {
+        "provider": "autogen.agentchat.teams.RoundRobinGroupChat",
         "responsibilities": [agent_name],
         "config": {"participants": [{"config": {"name": agent_name}}]},
     }

--- a/tests/test_skill_lookup.py
+++ b/tests/test_skill_lookup.py
@@ -23,12 +23,13 @@ class BarAgent(BaseAgent):
 
 def _write_team(tmp_path: Path) -> Path:
     cfg = {
+        "provider": "autogen.agentchat.teams.RoundRobinGroupChat",
         "config": {
             "participants": [
                 {"config": {"name": "foo_agent"}},
                 {"config": {"name": "bar_agent"}},
             ]
-        }
+        },
     }
     path = tmp_path / "team.json"
     path.write_text(json.dumps(cfg))

--- a/tests/test_solution_orchestrator.py
+++ b/tests/test_solution_orchestrator.py
@@ -22,6 +22,7 @@ class DummyAgentB(BaseAgent):
 
 def _write_team(tmp_path: Path, agent_name: str) -> Path:
     config = {
+        "provider": "autogen.agentchat.teams.RoundRobinGroupChat",
         "responsibilities": [agent_name],
         "config": {"participants": [{"config": {"name": agent_name}}]},
     }

--- a/tests/test_team_orchestrator.py
+++ b/tests/test_team_orchestrator.py
@@ -5,7 +5,7 @@ import pytest
 from pathlib import Path
 
 from src.base_orchestrator import BaseOrchestrator
-from src.team_orchestrator import TeamOrchestrator
+from src.team_orchestrator import TeamOrchestrator, validate_team_config
 from src.agents.base_agent import BaseAgent
 
 
@@ -16,6 +16,7 @@ class DummyAgent(BaseAgent):
 
 def _write_team(tmp_path: Path) -> Path:
     cfg = {
+        "provider": "autogen.agentchat.teams.RoundRobinGroupChat",
         "responsibilities": ["dummy_agent"],
         "config": {"participants": [{"config": {"name": "dummy_agent"}}]},
     }
@@ -51,3 +52,22 @@ def test_team_orchestrator_responsibility_check(tmp_path):
 
     with pytest.raises(ValueError):
         TeamOrchestrator(str(path))
+
+
+def test_validate_team_config(tmp_path):
+    valid = {
+        "provider": "autogen.agentchat.teams.RoundRobinGroupChat",
+        "config": {"participants": [{"config": {"name": "dummy"}}]},
+    }
+    validate_team_config(valid)
+
+    invalid = {}
+    with pytest.raises(Exception):
+        validate_team_config(invalid)
+
+
+def test_team_orchestrator_schema_failure(tmp_path):
+    bad_file = tmp_path / "bad.json"
+    bad_file.write_text("{}")
+    with pytest.raises(ValueError):
+        TeamOrchestrator(str(bad_file))


### PR DESCRIPTION
## Summary
- define docs/team_schema.json
- validate team configs in TeamOrchestrator using jsonschema
- add `brookside-cli validate-team` command
- include fallback jsonschema stub for test environment
- update tests for new schema validation
- document new schema and CLI usage

## Testing
- `pytest -q`

------
