### PR TITLE
Add SSE support to history viewer

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -36,3 +36,19 @@ bundle:
 ```
 
 This fallback enables dynamic key assignment without rebuilding the frontend.
+
+## Live History Streaming
+
+`HistoryViewer` now streams real-time activity using Server-Sent Events (SSE).
+It connects to the `/teams/<name>/stream` endpoint via `EventSource` and
+appends incoming `activity` messages to the list. By default the component
+listens to the `sales` team, but any team name can be provided:
+
+```jsx
+<HistoryViewer team="demo" />
+```
+
+When the page loads it fetches the latest history snapshot and then establishes
+the streaming connection. The API key configured through `VITE_API_KEY` or
+`window.APP_CONFIG.apiKey` is automatically included as the `api_key` query
+parameter.

--- a/frontend/__tests__/HistoryViewer.test.jsx
+++ b/frontend/__tests__/HistoryViewer.test.jsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import HistoryViewer from '../src/HistoryViewer.jsx';
+
+let lastInstance;
+class MockEventSource {
+  constructor(url) {
+    this.url = url;
+    this.listeners = {};
+    lastInstance = this;
+  }
+  addEventListener(type, cb) {
+    this.listeners[type] = cb;
+  }
+  close() {
+    this.closed = true;
+  }
+  emit(type, data) {
+    if (this.listeners[type]) this.listeners[type]({ data });
+  }
+}
+
+vi.stubGlobal('EventSource', MockEventSource);
+vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({ history: [] }) })));
+vi.stubEnv('VITE_API_KEY', 'secret');
+
+describe('HistoryViewer', () => {
+  afterEach(() => {
+    fetch.mockClear();
+  });
+
+  it('subscribes to stream and updates list on activity', () => {
+    render(<HistoryViewer team="demo" />);
+    expect(lastInstance.url).toBe('/teams/demo/stream?api_key=secret');
+    lastInstance.emit('activity', JSON.stringify({ event: { type: 'lead' }, result: { ok: true } }));
+    expect(screen.getByText(/lead/)).toBeInTheDocument();
+    expect(screen.getByText(/"ok": true/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- stream history updates using EventSource in HistoryViewer
- mock SSE in new HistoryViewer tests
- document streaming behaviour in the frontend README
- cover /teams/<name>/stream endpoint in API tests

## Testing
- `npm test --prefix frontend` *(fails: vitest not found)*
- `pytest -q`

------
