### PR TITLE
Add plugin management utilities and CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,11 @@ brookside-cli status
 # map a natural language task to a workflow template
 brookside-cli assist "handle new inventory"
 # => {"template": "src/teams/inventory_management_team.json"}
+
+# inspect available integrations
+brookside-cli list-agents    # built-in and entry-point agents
+brookside-cli list-plugins   # tool plugins
+brookside-cli show-plugin email_plugin
 ```
 
 A helper utility ``brookside-assistant`` extracts campaign parameters from free

--- a/src/cli.py
+++ b/src/cli.py
@@ -14,6 +14,8 @@ if __package__ in {None, ""}:  # pragma: no cover - script execution support
     sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
     __package__ = "src"
 
+from . import plugin_manager
+
 
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8765
@@ -163,6 +165,22 @@ def cmd_status(args: argparse.Namespace) -> None:
     print(json.dumps(resp))
 
 
+def cmd_list_agents(args: argparse.Namespace) -> None:
+    """Print available agent identifiers."""
+    print(json.dumps({"agents": plugin_manager.list_agents()}))
+
+
+def cmd_list_plugins(args: argparse.Namespace) -> None:
+    """Print available tool plugin identifiers."""
+    print(json.dumps({"plugins": plugin_manager.list_plugins()}))
+
+
+def cmd_show_plugin(args: argparse.Namespace) -> None:
+    """Display details about a specific plugin."""
+    info = plugin_manager.get_plugin_details(args.name)
+    print(json.dumps(info))
+
+
 def _match_workflow(task: str) -> str | None:
     """Return the workflow template matching ``task`` if any."""
 
@@ -221,6 +239,16 @@ def build_parser() -> argparse.ArgumentParser:
     status_p.add_argument("--host", default=DEFAULT_HOST, help="Server address")
     status_p.add_argument("--port", type=int, default=DEFAULT_PORT, help="Server port")
     status_p.set_defaults(func=cmd_status)
+
+    sub.add_parser("list-agents", help="List available agents").set_defaults(
+        func=cmd_list_agents
+    )
+    sub.add_parser("list-plugins", help="List available tool plugins").set_defaults(
+        func=cmd_list_plugins
+    )
+    show_p = sub.add_parser("show-plugin", help="Show details about a plugin")
+    show_p.add_argument("name", help="Plugin entry point or module name")
+    show_p.set_defaults(func=cmd_show_plugin)
 
     return parser
 

--- a/src/plugin_manager.py
+++ b/src/plugin_manager.py
@@ -1,0 +1,62 @@
+"""Utilities for discovering agents and tool plugins."""
+
+from __future__ import annotations
+
+import inspect
+from importlib import metadata
+from pathlib import Path
+from typing import Any, Dict, List
+
+from .utils.plugin_loader import (
+    ENTRY_POINT_GROUP,
+    ENTRY_POINT_PLUGINS,
+    load_plugin,
+)
+
+
+def _iter_entry_points(group: str) -> List[str]:
+    """Return entry point names registered under ``group``."""
+    try:
+        return [ep.name for ep in metadata.entry_points(group=group)]
+    except TypeError:  # pragma: no cover - Python <3.10 fallback
+        eps = metadata.entry_points()
+        return [ep.name for ep in eps.get(group, [])]
+
+
+def list_agents() -> List[str]:
+    """Return available agent names.
+
+    Agents can be provided via the ``brookside.agents`` entry point group
+    or as modules under :mod:`src.agents`.
+    """
+
+    names = set(_iter_entry_points(ENTRY_POINT_GROUP))
+    base = Path(__file__).resolve().parent / "agents"
+    for path in base.rglob("*.py"):
+        if path.name == "__init__.py" or path.name.startswith("_"):
+            continue
+        rel = path.relative_to(base).with_suffix("")
+        names.add(".".join(rel.parts))
+    return sorted(names)
+
+
+def list_plugins() -> List[str]:
+    """Return available tool plugin names."""
+
+    names = set(_iter_entry_points(ENTRY_POINT_PLUGINS))
+    base = Path(__file__).resolve().parent / "plugins"
+    for path in base.glob("*.py"):
+        if path.name in {"__init__.py", "base_plugin.py"} or path.name.startswith("_"):
+            continue
+        names.add(path.stem)
+    return sorted(names)
+
+
+def get_plugin_details(name: str) -> Dict[str, Any]:
+    """Return metadata for the plugin identified by ``name``."""
+    cls = load_plugin(name)
+    return {
+        "class": f"{cls.__module__}.{cls.__name__}",
+        "name": getattr(cls, "name", ""),
+        "doc": inspect.getdoc(cls) or "",
+    }

--- a/tests/test_cli_plugin_commands.py
+++ b/tests/test_cli_plugin_commands.py
@@ -1,0 +1,27 @@
+import json
+import subprocess
+import sys
+
+
+def test_cli_list_plugins():
+    cmd = [sys.executable, "-m", "src.cli", "list-plugins"]
+    res = subprocess.run(cmd, capture_output=True, text=True, timeout=5)
+    assert res.returncode == 0
+    data = json.loads(res.stdout.strip())
+    assert "email_plugin" in data["plugins"]
+
+
+def test_cli_show_plugin():
+    cmd = [sys.executable, "-m", "src.cli", "show-plugin", "email_plugin"]
+    res = subprocess.run(cmd, capture_output=True, text=True, timeout=5)
+    assert res.returncode == 0
+    data = json.loads(res.stdout.strip())
+    assert data["class"].endswith("EmailPlugin")
+
+
+def test_cli_list_agents():
+    cmd = [sys.executable, "-m", "src.cli", "list-agents"]
+    res = subprocess.run(cmd, capture_output=True, text=True, timeout=5)
+    assert res.returncode == 0
+    data = json.loads(res.stdout.strip())
+    assert "sales.lead_capture_agent" in data["agents"]

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -1,0 +1,71 @@
+import importlib.metadata
+import sys
+import types
+
+from src.plugin_manager import list_plugins, list_agents, get_plugin_details
+from src.plugins.base_plugin import BaseToolPlugin
+
+
+class DummyPlugin(BaseToolPlugin):
+    """Dummy plugin used for discovery tests."""
+
+    name = "dummy"
+
+    def execute(self, payload):
+        return True
+
+
+def test_list_plugins_builtin():
+    names = list_plugins()
+    assert "email_plugin" in names
+
+
+def test_list_plugins_entry_point(monkeypatch):
+    mod = types.ModuleType("dummy_mod")
+    mod.Tool = DummyPlugin
+    sys.modules["dummy_mod"] = mod
+
+    ep = importlib.metadata.EntryPoint(
+        "dummy_entry", "dummy_mod:Tool", "brookside.plugins"
+    )
+    monkeypatch.setattr(importlib.metadata, "entry_points", lambda group=None: [ep])
+
+    names = list_plugins()
+    assert "dummy_entry" in names
+
+
+def test_get_plugin_details(monkeypatch):
+    mod = types.ModuleType("detail_mod")
+    mod.Tool = DummyPlugin
+    sys.modules["detail_mod"] = mod
+
+    ep = importlib.metadata.EntryPoint("detail", "detail_mod:Tool", "brookside.plugins")
+    monkeypatch.setattr(importlib.metadata, "entry_points", lambda group=None: [ep])
+
+    info = get_plugin_details("detail")
+    assert info["class"].endswith("DummyPlugin")
+    assert info["name"] == "dummy"
+    assert "dummy plugin" in info["doc"].lower()
+
+
+def test_list_agents_builtin():
+    names = list_agents()
+    assert "sales.lead_capture_agent" in names
+
+
+def test_list_agents_entry_point(monkeypatch):
+    mod = types.ModuleType("dummy_agent_mod")
+
+    class DummyAgent:
+        pass
+
+    mod.Agent = DummyAgent
+    sys.modules["dummy_agent_mod"] = mod
+
+    ep = importlib.metadata.EntryPoint(
+        "dummy_agent", "dummy_agent_mod:Agent", "brookside.agents"
+    )
+    monkeypatch.setattr(importlib.metadata, "entry_points", lambda group=None: [ep])
+
+    names = list_agents()
+    assert "dummy_agent" in names


### PR DESCRIPTION
## Summary
- implement `plugin_manager` module for listing agents/plugins and inspecting plugins
- extend CLI with `list-agents`, `list-plugins`, and `show-plugin`
- add comprehensive tests for plugin manager and CLI
- document plugin commands in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68552a745820832b9a25e1838aaa16bb