### PR TITLE
Add CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing Guide
+
+Thank you for considering a contribution to this project! This document outlines how to set up a development environment and the conventions we follow for code style and commit messages.
+
+## Development Environment
+
+1. **Install Dependencies**
+
+   Install the required packages and any optional development extras. The
+   `pre-commit` tool is not bundled in `requirements.txt`, so install it
+   separately:
+   
+   ```bash
+   pip install -r requirements.txt
+   # If the project defines extras for development use:
+   pip install -e '.[dev]'
+   # Install pre-commit for Git hooks
+   pip install pre-commit
+   ```
+
+2. **Set Up Pre-commit Hooks**
+   
+   ```bash
+   pre-commit install
+   ```
+   This installs git hooks that automatically format code with **black**, lint with **flake8**, and run the unit tests via **pytest** before each commit.
+
+3. **Run the Test Suite**
+   
+   ```bash
+   pytest -q
+   ```
+   Ensure all tests pass before opening a pull request.
+
+## Code Style
+
+We follow **PEP8** conventions and require type hints for new code. The `pre-commit` hooks run **black** and **flake8** to enforce formatting and style automatically.
+
+## Commit Messages
+
+Use the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format in the *imperative mood*.
+Example messages:
+
+- `feat: add new CRM connector`
+- `fix: handle missing API key`
+- `docs: update README`
+
+This style ensures a consistent and readable project history.
+
+---
+
+For further details about the project architecture and workflow, see the [README](README.md).

--- a/README.md
+++ b/README.md
@@ -496,14 +496,7 @@ See [docs/workflows.md](docs/workflows.md) for a detailed overview.
 
 ## 🤝 Contributing
 
-We welcome community contributions! Install the pre-commit hooks so your changes follow our formatting and style guidelines.
-
-```bash
-pip install pre-commit
-pre-commit install
-```
-
-Running `pre-commit` will automatically format code with **black**, lint with **flake8**, and run the unit tests via **pytest** before each commit.
+We welcome community contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for a full guide on setting up a development environment, running the test suite, and our commit conventions.
 
 ## 🔗 Workflow Editor
 


### PR DESCRIPTION
## Summary
- add a CONTRIBUTING guide describing development setup, style, and commit conventions
- link to the contributing guide from the README
- mention installing pre-commit in the docs

## Testing
- `pytest -q`
- ⚠️ `pre-commit` *(failed: command not found)*

------
L