### PR TITLE
Add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,48 @@
+name: "\U0001F41B Bug Report"
+description: Report a reproducible problem
+labels: [bug]
+title: "[Bug]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+        Please provide as much detail as possible.
+  - type: textarea
+    id: reproduction_steps
+    attributes:
+      label: Reproduction steps
+      description: "How do we trigger the bug?"
+      placeholder: |
+        1. Go to '...'
+        2. Run '...'
+        3. Observe the failure
+    validations:
+      required: true
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual_behavior
+    attributes:
+      label: Actual behavior
+      description: What actually happened?
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment details
+      description: |
+        OS, Python version, package versions, and any other relevant information.
+    validations:
+      required: true
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,43 @@
+name: "\U0001F680 Feature Request"
+description: Suggest an improvement or new idea
+labels: [enhancement]
+title: "[Feature]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to propose a feature!
+  - type: textarea
+    id: reproduction_steps
+    attributes:
+      label: Use case / steps
+      description: |
+        Provide an example scenario or steps where this feature would be helpful.
+      placeholder: |
+        1. When ...
+        2. Then ...
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected behavior
+      description: How should the system behave with this feature?
+    validations:
+      required: true
+  - type: textarea
+    id: actual_behavior
+    attributes:
+      label: Current behavior
+      description: How does the system behave without this feature?
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment details
+      description: |
+        OS, Python version, packages, or other relevant environment information.
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Any other context or screenshots about the feature request.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+# Pull Request
+
+Thanks for contributing! Please review the checklist below.
+
+## Summary
+<!-- Provide a concise description of your changes -->
+
+## Related Issues
+<!-- Link relevant issues with closing keywords (e.g., Closes #123) -->
+
+## Checklist
+- [ ] Linked the issue(s) this PR resolves
+- [ ] Summarized the changes
+- [ ] Updated or added tests
+- [ ] Updated documentation as needed


### PR DESCRIPTION
## Summary
- add GitHub issue templates for bug reports and feature requests
- include reproduction steps, expected vs actual behaviour, and environment details
- add pull request template reminding contributors to link issues, summarize changes, and confirm test/doc updates

## Testing
- `pytest -q`

------
