### PR TITLE
Add dev requirements file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,16 +6,15 @@ Thank you for considering a contribution to this project! This document outlines
 
 1. **Install Dependencies**
 
-   Install the required packages and any optional development extras. The
-   `pre-commit` tool is not bundled in `requirements.txt`, so install it
-   separately:
-   
+   Install the runtime requirements alongside the development tools from
+   `requirements-dev.txt`. These include the test runner, `pre-commit`
+   hooks and documentation utilities:
+
    ```bash
    pip install -r requirements.txt
+   pip install -r requirements-dev.txt
    # If the project defines extras for development use:
    pip install -e '.[dev]'
-   # Install pre-commit for Git hooks
-   pip install pre-commit
    ```
 
 2. **Set Up Pre-commit Hooks**

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+# Additional packages useful for development and documentation
+pytest>=7.4
+pre-commit>=3.7
+sphinx>=7.2


### PR DESCRIPTION
## Summary
- support local development by listing pytest, pre-commit and sphinx in **requirements-dev.txt**
- update contributing docs with instructions to install dev dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685533c4dac4832b9852a3ee3f356470