### PR TITLE
Add docs landing page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,3 +2,10 @@ title: Markus Ahling
 remote_theme: pages-themes/minimal@v0.2.0
 plugins:
 - jekyll-remote-theme
+include:
+  - docs
+defaults:
+  - scope:
+      path: "docs/index.md"
+    values:
+      permalink: /

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,17 @@
+---
+layout: default
+title: Documentation
+permalink: /
+---
+
+# Brookside BI Documentation
+
+Welcome to the Brookside BI documentation. Here you'll find guides and references for working with the autonomous agents that power the system.
+
+## Key Guides
+
+- [Architecture Overview](architecture.md) – Understand how the pieces fit together.
+- [Component Guide](components.md) – Dive into the modules and orchestrators.
+- [Environment Variable Reference](environment.md) – Configure your runtime environment.
+
+For more topics, browse the other documents in this folder.


### PR DESCRIPTION
## Summary
- add a `docs/index.md` landing page
- configure Jekyll so the docs index becomes the site home

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685533c64548832b96349577f33d7268