### PR TITLE
Add debugger agent unit tests

### DIFF
--- a/tests/test_debugger_agent.py
+++ b/tests/test_debugger_agent.py
@@ -1,32 +1,101 @@
+import types
 from agentic_core import EventBus
 import src.debugger_agent as dbg
 from src.debugger_agent import DebuggerAgent
 
 
-def test_debugger_agent_success(monkeypatch):
+def make_openai_stub(result: str):
+    """Return an object mimicking the minimal OpenAI API used by DebuggerAgent."""
+    message = types.SimpleNamespace(content=result)
+    choice = types.SimpleNamespace(message=message)
+    response = types.SimpleNamespace(choices=[choice])
+
+    class StubChatCompletion:
+        @staticmethod
+        def create(*args, **kwargs):
+            return response
+
+    return types.SimpleNamespace(ChatCompletion=StubChatCompletion())
+
+
+def test_run_opens_pr_and_uses_ask_gpt(monkeypatch):
     bus = EventBus()
     agent = DebuggerAgent(bus)
-    monkeypatch.setattr(agent, "_ask_gpt", lambda ctx: "diff --git a b")
-    calls = []
-    monkeypatch.setattr(dbg, "open_pr", lambda diff: calls.append(diff))
+
+    monkeypatch.setattr(dbg, "openai", make_openai_stub("diff --git a b"))
+
+    seen = []
+    orig = agent._ask_gpt
+
+    def wrapper(ctx: str) -> str:
+        seen.append(ctx)
+        return orig(ctx)
+
+    monkeypatch.setattr(agent, "_ask_gpt", wrapper)
+
+    pr_calls = []
+    monkeypatch.setattr(dbg, "open_pr", lambda diff: pr_calls.append(diff))
     monkeypatch.setattr(dbg, "GITHUB_ENABLED", True)
-    out = agent.run({"trace": "boom"})
-    assert out == {"diff": "diff --git a b"}
-    assert calls == ["diff --git a b"]
+
+    result = agent.run({"trace": "boom"})
+
+    assert result == {"diff": "diff --git a b"}
+    assert seen == ["boom"]
+    assert pr_calls == ["diff --git a b"]
 
 
-def test_debugger_agent_failure(monkeypatch):
+def test_run_handles_exception(monkeypatch):
     bus = EventBus()
     agent = DebuggerAgent(bus)
 
-    def boom(ctx):
-        raise RuntimeError("bad")
+    class FailingChatCompletion:
+        @staticmethod
+        def create(*args, **kwargs):
+            raise RuntimeError("bad")
 
-    monkeypatch.setattr(agent, "_ask_gpt", boom)
-    calls = []
-    monkeypatch.setattr(dbg, "open_pr", lambda diff: calls.append(diff))
+    monkeypatch.setattr(dbg, "openai", types.SimpleNamespace(ChatCompletion=FailingChatCompletion()))
+
+    seen = []
+    orig = agent._ask_gpt
+
+    def wrapper(ctx: str) -> str:
+        seen.append(ctx)
+        return orig(ctx)
+
+    monkeypatch.setattr(agent, "_ask_gpt", wrapper)
+
+    pr_calls = []
+    monkeypatch.setattr(dbg, "open_pr", lambda diff: pr_calls.append(diff))
     monkeypatch.setattr(dbg, "GITHUB_ENABLED", True)
 
-    out = agent.run({"trace": "boom"})
-    assert out == {"diff": ""}
-    assert calls == []
+    result = agent.run({"trace": "boom"})
+
+    assert result == {"diff": ""}
+    assert seen == ["boom"]
+    assert pr_calls == []
+
+
+def test_run_without_github(monkeypatch):
+    bus = EventBus()
+    agent = DebuggerAgent(bus)
+
+    monkeypatch.setattr(dbg, "openai", make_openai_stub("diff --git a b"))
+
+    seen = []
+    orig = agent._ask_gpt
+
+    def wrapper(ctx: str) -> str:
+        seen.append(ctx)
+        return orig(ctx)
+
+    monkeypatch.setattr(agent, "_ask_gpt", wrapper)
+
+    pr_calls = []
+    monkeypatch.setattr(dbg, "open_pr", lambda diff: pr_calls.append(diff))
+    monkeypatch.setattr(dbg, "GITHUB_ENABLED", False)
+
+    result = agent.run({"trace": "boom"})
+
+    assert result == {"diff": "diff --git a b"}
+    assert seen == ["boom"]
+    assert pr_calls == []


### PR DESCRIPTION
## Summary
- add thorough unit tests for DebuggerAgent
- stub out OpenAI client responses and validate PR behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855eba587dc832baba9672c43468975