### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Build distribution
+        run: python -m build
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/*
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+
+  docker:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+          platforms: linux/amd64,linux/arm64

--- a/README.md
+++ b/README.md
@@ -578,6 +578,20 @@ Run the tests with `npm test`. Building the project outputs both the editor and
 dashboard into `dist/` using the shared `vite.config.js`. The dashboard's
 "Live Stream" section showcases the `/teams/<name>/stream` endpoint in action.
 
+## 📦 Release Process
+
+Releases are automated through GitHub Actions. Pushing a tag matching
+`v*.*.*` triggers a workflow that:
+
+1. Builds the Python package using `python -m build`.
+2. Creates multi-architecture Docker images (`linux/amd64` and `linux/arm64`).
+3. Publishes the images to Docker Hub or GHCR using credentials from repository
+   secrets (`DOCKER_USERNAME` and `DOCKER_PASSWORD`).
+4. Uploads the wheel and source distribution files as assets on the GitHub
+   release.
+
+Ensure the appropriate secrets are configured before tagging a release.
+
 ---
 
 This project is released under the [MIT License](LICENSE).

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,0 +1,26 @@
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+from pathlib import Path
+
+
+def test_release_workflow_structure():
+    """Ensure the release workflow parses and contains expected steps."""
+    wf_file = Path('.github/workflows/release.yml')
+    assert wf_file.exists(), 'release.yml missing'
+    data = yaml.safe_load(wf_file.read_text())
+
+    # Trigger
+    push = data.get('on', {}).get('push', {})
+    assert 'tags' in push and 'v*.*.*' in push['tags']
+
+    # Build job must run python -m build
+    build_steps = data['jobs']['build']['steps']
+    assert any('python -m build' in (step.get('run') or '') for step in build_steps)
+
+    # Docker job must build multi-arch images
+    docker_steps = data['jobs']['docker']['steps']
+    build_push = [s for s in docker_steps if s.get('uses', '').startswith('docker/build-push-action')]
+    assert build_push, 'docker build step missing'
+    assert 'linux/amd64,linux/arm64' in build_push[0]['with']['platforms']


### PR DESCRIPTION
## Summary
- build multi-arch Docker images and Python dists on version tags
- push images to a registry using secrets
- upload artifacts to GitHub releases
- document release process in README
- test release workflow structure

## Testing
- `pytest -q`
- `pre-commit run --files .github/workflows/release.yml README.md tests/test_release_workflow.py` *(fails: command not found)*

