### PR TITLE
Update CI workflow with multi-version test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,20 +8,36 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.9, 3.10, 3.11]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "${{ matrix.python-version }}"
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pre-commit
-          pip install mypy
+          pip install -r requirements-dev.txt
+      - name: Check formatting
+        run: black --check .
+      - name: Run flake8
+        run: flake8
       - name: Run mypy
         run: mypy .
-      - name: Run pre-commit
-        run: pre-commit run --all-files --show-diff-on-failure
       - name: Run tests
-        run: pytest -q
+        run: pytest -q --cov=src --cov-report=xml
+      - name: Upload coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ For a deeper explanation of the architecture—including the event bus, memory s
 
 ## ⚡ Quick Start
 
+This project supports **Python 3.9, 3.10 and 3.11**. All three versions are
+tested automatically in CI so you can develop with confidence on any of them.
+
 Install the requirements, set up pre-commit hooks and run the unit tests to verify your environment:
 
 ```bash


### PR DESCRIPTION
## Summary
- add Python 3.9-3.11 test matrix and caching to CI
- run black, flake8, mypy and pytest with coverage in CI
- upload coverage artifact
- document supported Python versions in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d86b3b6e8832bb5c771c092fb37d6