### PR TITLE
Add commit message linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,5 +23,9 @@ jobs:
         run: mypy .
       - name: Run pre-commit
         run: pre-commit run --all-files --show-diff-on-failure
+      - name: Lint commit message
+        run: |
+          echo "$(git log -1 --pretty=%B)" > commit_message.txt
+          pre-commit run --hook-stage commit-msg --commit-msg-filename commit_message.txt
       - name: Run tests
         run: pytest -q

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,11 @@ repos:
     hooks:
       - id: mypy
         args: [--ignore-errors]
+  - repo: https://github.com/conventional-pre-commit/conventional-pre-commit
+    rev: v3.1.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
   - repo: local
     hooks:
       - id: pytest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,10 @@ Example messages:
 
 This style ensures a consistent and readable project history.
 
+All commits are automatically validated when you run `pre-commit`. The commit
+message hook will reject commits that do not follow the Conventional Commits
+style.
+
 ---
 
 For further details about the project architecture and workflow, see the [README](README.md).

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ mypy .
 pytest -q
 ```
 
+Commit messages are checked for [Conventional Commits](https://www.conventionalcommits.org/) compliance when pre-commit hooks run.
+
 You can exercise the orchestrator with a single team using a few lines of Python:
 
 ```python


### PR DESCRIPTION
## Summary
- add conventional commit validation via `conventional-pre-commit`
- run commit message linting in CI
- document automatic commit message validation

## Testing
- `pytest -q`
- `pre-commit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d89a3c73c832b9f1ac4e0dac2d34b