### PR TITLE
Add YAML team config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ A trimmed example from `sales_team_full.json` looks like:
 
 ### 🧩 Team & Solution Orchestrators
 
-Teams packaged as JSON in `src/teams/` can now be loaded at runtime using `TeamOrchestrator`. It creates all agents listed under `participants` and provides an `EventBus` for intra-team messaging. Multiple teams are combined with `SolutionOrchestrator` which routes events to the appropriate team and collects their results.
+Teams packaged as JSON or YAML in `src/teams/` can now be loaded at runtime using `TeamOrchestrator`. It creates all agents listed under `participants` and provides an `EventBus` for intra-team messaging. Multiple teams are combined with `SolutionOrchestrator` which routes events to the appropriate team and collects their results.
 
 To initialise:
 ```python
@@ -108,6 +108,11 @@ orch = SolutionOrchestrator({
     "sales": "src/teams/sales_team_full.json",
     "operations": "src/teams/operations_team.json",
 })
+# YAML equivalents are also accepted
+# orch = SolutionOrchestrator({
+#     "sales": "src/teams/sales_team_full.yaml",
+#     "operations": "src/teams/operations_team.yaml",
+# })
 orch.handle_event("sales", {"type": "lead_capture", "payload": {}})
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -89,7 +89,7 @@ If ``config_path`` is not provided, a built-in default mapping identical to the 
 
 ### TeamOrchestrator
 
-`src.team_orchestrator.TeamOrchestrator` loads a single AutoGen team from JSON.  When instantiated it:
+`src.team_orchestrator.TeamOrchestrator` loads a single AutoGen team from JSON or YAML.  When instantiated it:
 
 1. Reads the team configuration file.
 2. For each participant entry, dynamically imports the agent class using
@@ -103,7 +103,7 @@ All AutoGen import statements therefore execute when the team orchestrator is co
 `SolutionOrchestrator` creates each team orchestrator when it is instantiated.
 For every entry in the `team_configs` mapping the following steps occur:
 
-1. A :class:`TeamOrchestrator` is constructed which loads the team JSON.
+1. A :class:`TeamOrchestrator` is constructed which loads the team file.
 2. AutoGen reads the `provider` settings for every participant and instantiates the matching agent classes and model clients (for example `OpenAIChatCompletionClient`).
 3. Each agent registers callback functions on the team's :class:`EventBus` so messages can be routed internally.
 
@@ -116,7 +116,7 @@ At this point all AutoGen agents are live and waiting for events. Teams remain a
 
 ## AutoGen Agents and Providers
 
-Team JSON files under `src/teams/` describe `RoundRobinGroupChat` configurations.  Each agent entry specifies a `provider` such as `src.agents.roles.AssistantAgent` or `autogen.models.openai.OpenAIChatCompletionClient`.  When a team is loaded, these providers are instantiated and stitched together by AutoGen.  The full structure of a team file is defined in [`team_schema.json`](team_schema.json) and can be checked using `brookside-cli validate-team`.
+Team configuration files under `src/teams/` (either JSON or YAML) describe `RoundRobinGroupChat` configurations.  Each agent entry specifies a `provider` such as `src.agents.roles.AssistantAgent` or `autogen.models.openai.OpenAIChatCompletionClient`.  When a team is loaded, these providers are instantiated and stitched together by AutoGen.  The full structure of a team file is defined in [`team_schema.json`](team_schema.json) and can be checked using `brookside-cli validate-team`.
 
 Each team file may optionally include a `responsibilities` array listing the
 agent names allowed to operate within that team.  When a team is loaded the
@@ -127,7 +127,7 @@ OpenAI powered components (via `OpenAIChatCompletionClient`) are created using A
 
 ### AutoGen Invocation
 
-When `TeamOrchestrator.handle_event` receives an event it forwards the payload to the corresponding AutoGen agent. The agent's `model_client` (such as `OpenAIChatCompletionClient`) sends the message to the LLM and returns the response. AutoGen then orchestrates the conversation flow defined in the JSON configuration, cycling through the participants until a termination condition is met.
+When `TeamOrchestrator.handle_event` receives an event it forwards the payload to the corresponding AutoGen agent. The agent's `model_client` (such as `OpenAIChatCompletionClient`) sends the message to the LLM and returns the response. AutoGen then orchestrates the conversation flow defined in the team configuration, cycling through the participants until a termination condition is met.
 
 ## Execution Sequence
 
@@ -142,8 +142,8 @@ When `TeamOrchestrator.handle_event` receives an event it forwards the payload t
 
 1. Implement a new agent class under `src/agents/` deriving from `BaseAgent` and providing a `run()` method.
 2. Add any helper tools under `src/tools/` and register them with `@Tool` if using `agentic_core` utilities.
-3. Create a new team JSON mirroring those in `src/teams/`.  The `participants` section should reference your agent module names so that `TeamOrchestrator` can import them. Optionally include a `responsibilities` array listing the allowed agent names.
-4. Register the team with `SolutionOrchestrator` by mapping a name to the JSON file path.
+3. Create a new team file (JSON or YAML) mirroring those in `src/teams/`.  The `participants` section should reference your agent module names so that `TeamOrchestrator` can import them. Optionally include a `responsibilities` array listing the allowed agent names.
+4. Register the team with `SolutionOrchestrator` by mapping a name to the file path.
 
 With these pieces in place, events sent to the solution orchestrator will automatically activate your new team alongside the existing ones.
 
@@ -161,7 +161,7 @@ Beyond the standard setup you can extend almost every component:
 * **Custom Providers** – AutoGen agents rely on model providers for LLM access.
   You can create new providers for different AI services by implementing the
   same interface that `OpenAIChatCompletionClient` exposes and referencing that
-  class in your team JSON.
+  class in your team file.
 
 These extension points allow the Brookside framework to scale from unit tests to
 real-world deployments with minimal changes.


### PR DESCRIPTION
## Summary
- parse `.yaml`/`.yml` files in `TeamOrchestrator`
- document YAML team config support
- test YAML vs JSON team configs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687985a60d68832b9abd8ae7aa634164