### PR TITLE
Expand tool plugins with API support

### DIFF
--- a/docs/environment.md
+++ b/docs/environment.md
@@ -68,6 +68,8 @@ variables documented below.
 - `DB_CONNECTION_STRING` – Database URL.
 - `KAFKA_BOOTSTRAP_SERVERS` – Kafka broker list.
 - `RABBITMQ_URL` – RabbitMQ connection string.
+- `CLOUD_DOCS_API_URL` – Base URL for the cloud document service.
+- `CLOUD_DOCS_API_KEY` – Authentication token for the cloud docs API.
 
 ## Memory Service
 - `MEMORY_BACKEND` – Choose the persistence layer (`rest`, `file`, `redis`).
@@ -77,6 +79,7 @@ variables documented below.
 
 ## Messaging & Notifications
 - `SENDGRID_API_KEY` – SendGrid API key.
+- `DEFAULT_FROM_EMAIL` – Address used as the sender when none is provided.
 - `SLACK_WEBHOOK_URL` – Slack webhook for notifications.
 - `TEAMS_WEBHOOK_URL` – Microsoft Teams webhook.
 - `TWILIO_ACCOUNT_SID` – Twilio account SID.
@@ -139,3 +142,4 @@ variables documented below.
 - `CONFIG_PATH` – Path to the orchestrator configuration, defaults to `config/playbook.yaml`.
 - `API_AUTH_KEY` – Token required by the FastAPI server for requests.
 - `ALLOWED_ORIGINS` – Comma separated list of domains allowed for CORS requests.
+- `SCRAPER_USER_AGENT` – HTTP User-Agent string used by `ScrapingPlugin`.

--- a/src/config.py
+++ b/src/config.py
@@ -113,8 +113,12 @@ class Settings(BaseSettings):
     KAFKA_BOOTSTRAP_SERVERS: Optional[str] = None
     RABBITMQ_URL: Optional[str] = None
 
+    CLOUD_DOCS_API_URL: Optional[str] = None
+    CLOUD_DOCS_API_KEY: Optional[str] = None
+
     # Messaging & Notifications
     SENDGRID_API_KEY: Optional[str] = None
+    DEFAULT_FROM_EMAIL: str = "noreply@example.com"
     SLACK_WEBHOOK_URL: Optional[str] = None
     TEAMS_WEBHOOK_URL: Optional[str] = None
     FCM_SERVER_KEY: Optional[str] = None
@@ -169,6 +173,7 @@ class Settings(BaseSettings):
     CONFIG_PATH: str = "config/playbook.yaml"
     API_AUTH_KEY: Optional[str] = None
     ALLOWED_ORIGINS: str = "*"
+    SCRAPER_USER_AGENT: str = "BrooksideBot/1.0"
 
     # Memory Service
     MEMORY_BACKEND: Literal["rest", "rest_async", "file", "redis"] = "rest"

--- a/src/plugins/cloud_docs_plugin.py
+++ b/src/plugins/cloud_docs_plugin.py
@@ -1,6 +1,21 @@
-"""Example cloud document tool plugin."""
+"""Cloud document management plugin backed by a REST API.
+
+The plugin communicates with a cloud document service specified by
+``CLOUD_DOCS_API_URL`` and authenticated via ``CLOUD_DOCS_API_KEY``.  The
+``payload`` may contain an ``action`` path and a ``data`` dictionary.  The
+JSON response from the service is returned.  When ``requests`` is missing
+an empty result is produced so the rest of the application can still run
+in limited environments.
+"""
 
 from typing import Any, Dict
+
+try:  # pragma: no cover - optional dependency
+    import requests
+except Exception:  # pragma: no cover - optional dependency
+    requests = None
+
+from ..config import settings
 
 from .base_plugin import BaseToolPlugin
 import logging
@@ -13,6 +28,20 @@ class CloudDocsPlugin(BaseToolPlugin):
 
     name = "cloud_docs"
 
-    def execute(self, payload: Dict[str, Any]) -> Dict[str, str]:
-        logger.info("Stub cloud docs action: %s", payload)
-        return {"doc_id": "example"}
+    def execute(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Perform an action against the cloud document service."""
+
+        if not getattr(requests, "post", None):  # pragma: no cover - optional dep
+            logger.warning("requests package unavailable; returning empty result")
+            return {}
+
+        action = payload.get("action", "upload")
+        data = payload.get("data")
+
+        url = f"{settings.CLOUD_DOCS_API_URL}/{action}"
+        headers = {"Authorization": f"Bearer {settings.CLOUD_DOCS_API_KEY}"}
+
+        logger.info("CloudDocsPlugin calling %s", url)
+        resp = requests.post(url, json=data, headers=headers, timeout=5)
+        resp.raise_for_status()
+        return resp.json()

--- a/src/plugins/crm_plugin.py
+++ b/src/plugins/crm_plugin.py
@@ -1,6 +1,23 @@
-"""Example CRM tool plugin."""
+"""CRM tool plugin providing a minimal REST integration.
+
+``CRMPlugin`` posts payload data to the configured CRM API using the
+``requests`` library.  It expects ``settings.CRM_API_URL`` and
+``settings.CRM_API_KEY`` to be defined.  The payload may specify an
+``action`` (path appended to the base URL) and a ``data`` dictionary that
+is sent as JSON.  The method returns the decoded JSON response from the
+service.  When the optional ``requests`` dependency is missing a warning is
+logged and an empty dictionary is returned so tests can run without
+network access.
+"""
 
 from typing import Any, Dict
+
+try:  # pragma: no cover - optional dependency
+    import requests
+except Exception:  # pragma: no cover - optional dependency
+    requests = None
+
+from ..config import settings
 
 from .base_plugin import BaseToolPlugin
 import logging
@@ -14,5 +31,21 @@ class CRMPlugin(BaseToolPlugin):
     name = "crm"
 
     def execute(self, payload: Dict[str, Any]) -> Dict[str, Any]:
-        logger.info("Stub CRM action: %s", payload)
-        return {"ok": True}
+        """Send ``payload`` to the CRM API and return the JSON response."""
+
+        if not getattr(requests, "post", None):  # pragma: no cover - optional dep
+            logger.warning(
+                "requests package is unavailable; returning empty response"
+            )
+            return {}
+
+        action = payload.get("action", "record")
+        data = payload.get("data", {})
+
+        url = f"{settings.CRM_API_URL}/{action}"
+        headers = {"Authorization": f"Bearer {settings.CRM_API_KEY}"}
+
+        logger.info("CRMPlugin posting to %s", url)
+        resp = requests.post(url, json=data, headers=headers, timeout=5)
+        resp.raise_for_status()
+        return resp.json()

--- a/src/plugins/email_plugin.py
+++ b/src/plugins/email_plugin.py
@@ -1,6 +1,25 @@
-"""Example email tool plugin."""
+"""Email plugin using SendGrid for delivery.
+
+The plugin expects ``SENDGRID_API_KEY`` and ``DEFAULT_FROM_EMAIL`` in
+``Settings``.  The payload should contain ``to``, ``subject`` and ``html``
+keys.  ``execute`` returns ``True`` if the API call succeeds (2xx status
+code) otherwise ``False``.  Any exception raised by the SendGrid client is
+caught and logged so the orchestrator can continue running.
+"""
 
 from typing import Any, Dict
+
+import types
+import sys
+
+try:  # pragma: no cover - optional dependency
+    from sendgrid import SendGridAPIClient
+    from sendgrid.helpers.mail import Mail
+except Exception:  # pragma: no cover - optional dependency
+    SendGridAPIClient = None
+    Mail = None
+
+from ..config import settings
 
 from .base_plugin import BaseToolPlugin
 import logging
@@ -14,5 +33,29 @@ class EmailPlugin(BaseToolPlugin):
     name = "email"
 
     def execute(self, payload: Dict[str, Any]) -> bool:
-        logger.info("Stub email send: %s", payload)
-        return True
+        """Send an HTML email using SendGrid."""
+
+        if not (SendGridAPIClient and Mail):  # pragma: no cover - optional dep
+            logger.warning("sendgrid package not available; email not sent")
+            return False
+
+        to_email = payload.get("to")
+        subject = payload.get("subject", "")
+        html = payload.get("html", "")
+        from_email = payload.get("from_email", settings.DEFAULT_FROM_EMAIL)
+
+        client = SendGridAPIClient(settings.SENDGRID_API_KEY)
+        message = Mail(
+            from_email=from_email,
+            to_emails=to_email,
+            subject=subject,
+            html_content=html,
+        )
+
+        logger.info("EmailPlugin sending to %s", to_email)
+        try:
+            resp = client.send(message)
+            return 200 <= resp.status_code < 300
+        except Exception as exc:  # pragma: no cover - network call
+            logger.error("Email send failed: %s", exc)
+            return False

--- a/src/plugins/scraping_plugin.py
+++ b/src/plugins/scraping_plugin.py
@@ -1,6 +1,19 @@
-"""Example web scraping tool plugin."""
+"""Simple web scraping plugin using ``requests``.
+
+The plugin fetches HTML from the ``url`` in ``payload`` with a configurable
+``User-Agent`` header (``SCRAPER_USER_AGENT`` in :mod:`src.config`).  If the
+``requests`` package is unavailable it logs a warning and returns an empty
+string so unit tests can run without the dependency.
+"""
 
 from typing import Any, Dict
+
+try:  # pragma: no cover - optional dependency
+    import requests
+except Exception:  # pragma: no cover - optional dependency
+    requests = None
+
+from ..config import settings
 
 from .base_plugin import BaseToolPlugin
 import logging
@@ -9,10 +22,21 @@ logger = logging.getLogger(__name__)
 
 
 class ScrapingPlugin(BaseToolPlugin):
-    """Return dummy HTML for a URL."""
+    """Fetch HTML content for a URL."""
 
     name = "scraping"
 
     def execute(self, payload: Dict[str, Any]) -> str:
-        logger.info("Stub scrape: %s", payload)
-        return "<html></html>"
+        """Return the raw HTML for the requested URL."""
+
+        if not getattr(requests, "get", None):  # pragma: no cover - optional dep
+            logger.warning("requests package not available; returning empty page")
+            return ""
+
+        url = payload.get("url", "")
+        headers = {"User-Agent": settings.SCRAPER_USER_AGENT}
+
+        logger.info("ScrapingPlugin fetching %s", url)
+        resp = requests.get(url, headers=headers, timeout=5)
+        resp.raise_for_status()
+        return resp.text

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -52,3 +52,26 @@ def test_env_file_override(monkeypatch, tmp_path):
     mod = _reload_settings(monkeypatch, ENV_FILE=str(env_file))
     assert mod.settings.OPENAI_API_KEY == "from_override"
     _reload_settings(monkeypatch, ENV_FILE=None, OPENAI_API_KEY=None)
+
+
+def test_new_plugin_settings(monkeypatch):
+    """Ensure newly added plugin settings load from environment vars."""
+
+    env = {
+        "DEFAULT_FROM_EMAIL": "test@example.com",
+        "CLOUD_DOCS_API_URL": "http://docs",
+        "CLOUD_DOCS_API_KEY": "token",
+        "SCRAPER_USER_AGENT": "AgentBot",
+    }
+    mod = _reload_settings(monkeypatch, **env)
+    assert mod.settings.DEFAULT_FROM_EMAIL == "test@example.com"
+    assert mod.settings.CLOUD_DOCS_API_URL == "http://docs"
+    assert mod.settings.CLOUD_DOCS_API_KEY == "token"
+    assert mod.settings.SCRAPER_USER_AGENT == "AgentBot"
+    _reload_settings(
+        monkeypatch,
+        DEFAULT_FROM_EMAIL=None,
+        CLOUD_DOCS_API_URL=None,
+        CLOUD_DOCS_API_KEY=None,
+        SCRAPER_USER_AGENT=None,
+    )

--- a/tests/test_tool_plugins.py
+++ b/tests/test_tool_plugins.py
@@ -1,0 +1,122 @@
+import sys
+import types
+import importlib
+
+import pytest
+
+from src.config import settings
+
+
+def test_crm_plugin_execute(monkeypatch):
+    calls = {}
+
+    def fake_post(url, json=None, headers=None, timeout=5):
+        calls['url'] = url
+        calls['json'] = json
+        calls['headers'] = headers
+        return types.SimpleNamespace(json=lambda: {'ok': True}, raise_for_status=lambda: None)
+
+    crm_mod = importlib.reload(importlib.import_module('src.plugins.crm_plugin'))
+    monkeypatch.setattr(crm_mod, 'requests', types.SimpleNamespace(post=fake_post))
+    crm_mod.settings.CRM_API_URL = 'http://crm'
+    crm_mod.settings.CRM_API_KEY = 'key'
+    plugin = crm_mod.CRMPlugin()
+    res = plugin.execute({'action': 'record', 'data': {'name': 'Bob'}})
+
+    assert res == {'ok': True}
+    assert calls['url'] == 'http://crm/record'
+    assert calls['json'] == {'name': 'Bob'}
+    assert calls['headers'] == {'Authorization': 'Bearer key'}
+
+
+def test_crm_plugin_missing_requests(monkeypatch):
+    crm_mod = importlib.reload(importlib.import_module('src.plugins.crm_plugin'))
+    monkeypatch.setattr(crm_mod, 'requests', None)
+    crm_mod.settings.CRM_API_URL = 'http://crm'
+    crm_mod.settings.CRM_API_KEY = 'key'
+    assert crm_mod.CRMPlugin().execute({'action': 'x'}) == {}
+
+
+class DummyClient:
+    def __init__(self, api_key=None):
+        self.api_key = api_key
+
+    def send(self, message):
+        DummyClient.sent.append(message)
+        return types.SimpleNamespace(status_code=202)
+
+DummyClient.sent = []
+
+def setup_sendgrid(monkeypatch):
+    sendgrid_mail = types.SimpleNamespace(Mail=lambda **kw: types.SimpleNamespace(**kw))
+    sendgrid_helpers = types.SimpleNamespace(mail=sendgrid_mail)
+    sendgrid_stub = types.SimpleNamespace(SendGridAPIClient=DummyClient, helpers=sendgrid_helpers)
+    sys.modules['sendgrid'] = sendgrid_stub
+    sys.modules['sendgrid.helpers'] = sendgrid_helpers
+    sys.modules['sendgrid.helpers.mail'] = sendgrid_mail
+
+
+def test_email_plugin_execute(monkeypatch):
+    setup_sendgrid(monkeypatch)
+    monkeypatch.setattr(settings, 'SENDGRID_API_KEY', 'k')
+    monkeypatch.setattr(settings, 'DEFAULT_FROM_EMAIL', 'noreply@example.com')
+
+    email_mod = importlib.reload(importlib.import_module('src.plugins.email_plugin'))
+    plugin = email_mod.EmailPlugin()
+    res = plugin.execute({'to': 'u@example.com', 'subject': 'Hi', 'html': '<p>hi</p>'})
+
+    assert res is True
+    assert DummyClient.sent and DummyClient.sent[0].to_emails == 'u@example.com'
+
+
+def test_scraping_plugin_execute(monkeypatch):
+    calls = {}
+
+    def fake_get(url, headers=None, timeout=5):
+        calls['url'] = url
+        calls['headers'] = headers
+        return types.SimpleNamespace(text='<html>', raise_for_status=lambda: None)
+
+    scraping_mod = importlib.reload(importlib.import_module('src.plugins.scraping_plugin'))
+    monkeypatch.setattr(scraping_mod, 'requests', types.SimpleNamespace(get=fake_get))
+    scraping_mod.settings.SCRAPER_USER_AGENT = 'AgentBot'
+    html = scraping_mod.ScrapingPlugin().execute({'url': 'http://example.com'})
+
+    assert html == '<html>'
+    assert calls['headers'] == {'User-Agent': 'AgentBot'}
+
+
+def test_scraping_plugin_missing_requests(monkeypatch):
+    scraping_mod = importlib.reload(importlib.import_module('src.plugins.scraping_plugin'))
+    monkeypatch.setattr(scraping_mod, 'requests', None)
+    scraping_mod.settings.SCRAPER_USER_AGENT = 'AgentBot'
+    assert scraping_mod.ScrapingPlugin().execute({'url': 'http://x'}) == ''
+
+
+def test_cloud_docs_plugin_execute(monkeypatch):
+    calls = {}
+
+    def fake_post(url, json=None, headers=None, timeout=5):
+        calls['url'] = url
+        calls['json'] = json
+        calls['headers'] = headers
+        return types.SimpleNamespace(json=lambda: {'id': '1'}, raise_for_status=lambda: None)
+
+    cloud_mod = importlib.reload(importlib.import_module('src.plugins.cloud_docs_plugin'))
+    monkeypatch.setattr(cloud_mod, 'requests', types.SimpleNamespace(post=fake_post))
+    cloud_mod.settings.CLOUD_DOCS_API_URL = 'http://docs'
+    cloud_mod.settings.CLOUD_DOCS_API_KEY = 'token'
+    result = cloud_mod.CloudDocsPlugin().execute({'action': 'upload', 'data': {'name': 'a'}})
+
+    assert result == {'id': '1'}
+    assert calls['url'] == 'http://docs/upload'
+    assert calls['json'] == {'name': 'a'}
+    assert calls['headers'] == {'Authorization': 'Bearer token'}
+
+
+def test_cloud_docs_plugin_missing_requests(monkeypatch):
+    cloud_mod = importlib.reload(importlib.import_module('src.plugins.cloud_docs_plugin'))
+    monkeypatch.setattr(cloud_mod, 'requests', None)
+    cloud_mod.settings.CLOUD_DOCS_API_URL = 'http://docs'
+    cloud_mod.settings.CLOUD_DOCS_API_KEY = 'token'
+    assert cloud_mod.CloudDocsPlugin().execute({'action': 'x'}) == {}


### PR DESCRIPTION
## Summary
- implement real HTTP logic for CRM, Email, Scraping and Cloud Docs plugins
- add `CLOUD_DOCS_API_URL`, `CLOUD_DOCS_API_KEY`, `DEFAULT_FROM_EMAIL` and `SCRAPER_USER_AGENT` settings
- document new environment variables
- add unit tests for the plugins and new settings

## Testing
- `pytest -q`

------
