### PR TITLE
Add embedding memory backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,8 +425,9 @@ dotenv file before running the orchestrator or tests.
 | `CRM_API_URL` / `CRM_API_KEY` | Endpoint and key for your CRM integration used by `crm_connector.fetch_deals` |
 | `SENDGRID_API_KEY` | Sending transactional email |
 | `REDIS_URL` | Backend store for caching and message passing |
-| `MEMORY_BACKEND` | Selects memory service (`rest`, `file`, `redis`) |
+| `MEMORY_BACKEND` | Selects memory service (`rest`, `rest_async`, `file`, `redis`, `embedding`) |
 | `MEMORY_REDIS_URL` | Redis connection when `MEMORY_BACKEND=redis` |
+| `MEMORY_EMBED_FIELD` | Payload field containing text when `MEMORY_BACKEND=embedding` |
 | `SLACK_WEBHOOK_URL` | Post notifications to Slack channels |
 | `TEAMS_WEBHOOK_URL` | Microsoft Teams notifications |
 | `FACEBOOK_ACCESS_TOKEN` | Used by `AdTool` to create Facebook campaigns |

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -70,10 +70,11 @@ variables documented below.
 - `RABBITMQ_URL` – RabbitMQ connection string.
 
 ## Memory Service
-- `MEMORY_BACKEND` – Choose the persistence layer (`rest`, `file`, `redis`).
+- `MEMORY_BACKEND` – Choose the persistence layer (`rest`, `rest_async`, `file`, `redis`, `embedding`).
 - `MEMORY_ENDPOINT` – URL for the REST backend when `MEMORY_BACKEND=rest`.
 - `MEMORY_FILE_PATH` – File path when `MEMORY_BACKEND=file`.
 - `MEMORY_REDIS_URL` – Redis URL when `MEMORY_BACKEND=redis`.
+- `MEMORY_EMBED_FIELD` – Payload field containing text when `MEMORY_BACKEND=embedding`.
 
 ## Messaging & Notifications
 - `SENDGRID_API_KEY` – SendGrid API key.

--- a/docs/memory_service.md
+++ b/docs/memory_service.md
@@ -78,7 +78,7 @@ sequenceDiagram
 
 ## Swapping backends
 
-Four built-in backends are provided:
+Five built-in backends are provided:
 
 1. **REST** – the original implementation used for examples. Configure the
    endpoint via ``MEMORY_ENDPOINT``.
@@ -88,9 +88,12 @@ Four built-in backends are provided:
    ``MEMORY_FILE_PATH``.
 4. **Redis** – stores events in lists within a Redis instance using
    ``MEMORY_REDIS_URL``.
+5. **Embedding** – stores records in-memory and ranks them by cosine
+   similarity against the query string. Controlled with
+   ``MEMORY_EMBED_FIELD``.
 
 Select the backend using the ``MEMORY_BACKEND`` environment variable (``rest``,
-``rest_async``, ``file`` or ``redis``). The orchestrator reads these settings via ``src.config.Settings``
+``rest_async``, ``file``, ``redis`` or ``embedding``). The orchestrator reads these settings via ``src.config.Settings``
 so they can be placed in a ``.env`` file or exported in your shell.
 
 You can also provide your own implementation by subclassing

--- a/src/config.py
+++ b/src/config.py
@@ -171,10 +171,11 @@ class Settings(BaseSettings):
     ALLOWED_ORIGINS: str = "*"
 
     # Memory Service
-    MEMORY_BACKEND: Literal["rest", "rest_async", "file", "redis"] = "rest"
+    MEMORY_BACKEND: Literal["rest", "rest_async", "file", "redis", "embedding"] = "rest"
     MEMORY_ENDPOINT: str = "http://localhost:8000"
     MEMORY_FILE_PATH: str = "memory.jsonl"
     MEMORY_REDIS_URL: str = "redis://localhost:6379/0"
+    MEMORY_EMBED_FIELD: str = "text"
 
     # Logistics & E-commerce
     TMS_API_URL: Optional[str] = None

--- a/src/memory_service/__init__.py
+++ b/src/memory_service/__init__.py
@@ -8,6 +8,7 @@ except Exception:  # pragma: no cover - httpx missing
     AsyncRestMemoryService = None  # type: ignore
 from .file import FileMemoryService
 from .redis import RedisMemoryService
+from .embedding import EmbeddingMemoryService
 
 __all__ = [
     "BaseMemoryService",
@@ -15,4 +16,5 @@ __all__ = [
     "AsyncRestMemoryService",
     "FileMemoryService",
     "RedisMemoryService",
+    "EmbeddingMemoryService",
 ]

--- a/src/memory_service/embedding.py
+++ b/src/memory_service/embedding.py
@@ -1,0 +1,46 @@
+"""In-memory similarity search backend using simple vector embeddings."""
+
+from __future__ import annotations
+
+import math
+from collections import Counter
+from typing import Any, Dict, List, Tuple
+
+from .base import BaseMemoryService
+
+
+class EmbeddingMemoryService(BaseMemoryService):
+    """Store payloads and rank results using cosine similarity."""
+
+    def __init__(self, text_key: str = "text") -> None:
+        self.text_key = text_key
+        self._store: List[Tuple[Dict[str, int], Dict[str, Any]]] = []
+
+    def _embed(self, text: str) -> Dict[str, int]:
+        tokens = text.lower().split()
+        return Counter(tokens)
+
+    def _cosine(self, v1: Dict[str, int], v2: Dict[str, int]) -> float:
+        dot = sum(v1[t] * v2[t] for t in v1.keys() & v2.keys())
+        norm1 = math.sqrt(sum(v * v for v in v1.values()))
+        norm2 = math.sqrt(sum(v * v for v in v2.values()))
+        if norm1 == 0 or norm2 == 0:
+            return 0.0
+        return dot / (norm1 * norm2)
+
+    def store(self, key: str, payload: Dict[str, Any]) -> bool:
+        text = str(payload.get(self.text_key, ""))
+        vector = self._embed(text)
+        self._store.append((vector, payload))
+        return True
+
+    def fetch(self, key: str, top_k: int = 5) -> List[Dict[str, Any]]:
+        query_vec = self._embed(key)
+        ranked = sorted(
+            self._store,
+            key=lambda item: self._cosine(query_vec, item[0]),
+            reverse=True,
+        )
+        return [payload for _, payload in ranked[:top_k]]
+
+__all__ = ["EmbeddingMemoryService"]

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -37,6 +37,7 @@ from .memory_service import RestMemoryService
 from .memory_service.rest_async import AsyncRestMemoryService
 from .memory_service.file import FileMemoryService
 from .memory_service.redis import RedisMemoryService
+from .memory_service.embedding import EmbeddingMemoryService
 from .memory_service.base import BaseMemoryService
 from .config import settings
 import logging
@@ -111,7 +112,8 @@ class Orchestrator(BaseOrchestrator):
             Optional path to a JSON mapping of event types to agent classes.
         memory_backend:
             Select the memory implementation: ``"rest"`` (default), ``"rest_async"``,
-            ``"file"`` or ``"redis"``.
+            ``"file"``, ``"redis"`` or ``"embedding"`` for in-memory similarity
+            search.
         memory_file:
             Path used by the ``file`` backend if specified.
         """
@@ -125,6 +127,9 @@ class Orchestrator(BaseOrchestrator):
         elif backend == "redis":
             url = settings.MEMORY_REDIS_URL
             memory = RedisMemoryService(url)
+        elif backend == "embedding":
+            field = settings.MEMORY_EMBED_FIELD
+            memory = EmbeddingMemoryService(text_key=field)
         elif backend == "rest_async":
             endpoint = memory_endpoint or settings.MEMORY_ENDPOINT
             memory = AsyncRestMemoryService(endpoint)

--- a/tests/test_embedding_memory_service.py
+++ b/tests/test_embedding_memory_service.py
@@ -1,0 +1,18 @@
+from src.memory_service.embedding import EmbeddingMemoryService
+
+
+def test_similarity_ranking():
+    svc = EmbeddingMemoryService()
+    svc.store("", {"text": "the quick brown fox"})
+    svc.store("", {"text": "the fast brown fox"})
+    svc.store("", {"text": "lorem ipsum"})
+
+    res = svc.fetch("quick fox", top_k=2)
+    assert res[0]["text"] == "the quick brown fox"
+    assert res[1]["text"] == "the fast brown fox"
+    assert len(res) == 2
+
+
+def test_empty_result():
+    svc = EmbeddingMemoryService()
+    assert svc.fetch("anything") == []

--- a/tests/test_orchestrator_embedding_backend.py
+++ b/tests/test_orchestrator_embedding_backend.py
@@ -1,0 +1,32 @@
+import types
+import sys
+
+from src.orchestrator import Orchestrator
+from src.memory_service.embedding import EmbeddingMemoryService
+
+
+class DummyScheduler:
+    def create_event(self, cid, ev):
+        return {"id": "evt"}
+
+
+def test_orchestrator_embedding_backend(monkeypatch):
+    monkeypatch.setattr(
+        "src.tools.scheduler_tool.SchedulerTool",
+        lambda: DummyScheduler(),
+    )
+    sys.modules.setdefault(
+        "requests",
+        types.SimpleNamespace(
+            post=lambda *a, **k: types.SimpleNamespace(ok=True, json=lambda: {}),
+            get=lambda *a, **k: types.SimpleNamespace(ok=True, json=lambda: {}),
+        ),
+    )
+
+    orch = Orchestrator(memory_backend="embedding")
+    assert isinstance(orch.memory, EmbeddingMemoryService)
+
+    payload = {"form_data": {}, "source": "web"}
+    res = orch.handle_event_sync({"type": "lead_capture", "payload": payload})
+    assert res["status"] == "done"
+


### PR DESCRIPTION
## Summary
- add EmbeddingMemoryService for similarity search
- configure orchestrator and settings to use MEMORY_BACKEND=embedding
- document embedding backend in README and docs
- provide tests covering embedding memory usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68798ebaa0f0832b8e99bbd366a56aa8