### PR TITLE
Improve validate-team CLI output

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -115,6 +115,8 @@ def test_cli_validate_team(tmp_path):
     assert res_bad.returncode == 0
     out = json.loads(res_bad.stdout.strip())
     assert out["valid"] is False
+    # the CLI should include a descriptive error message when validation fails
+    assert isinstance(out.get("error"), str) and out["error"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- return jsonschema message in validate-team command
- test the error message from validate-team

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879e738c8f4832b804f766c003ef4e2