### PR TITLE
Add env.example and update README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+# Example environment variables for local development
+# Copy this file to `.env` and fill in real values as needed.
+
+# API keys and endpoints
+OPENAI_API_KEY=
+CRM_API_URL=
+CRM_API_KEY=
+SENDGRID_API_KEY=
+REDIS_URL=
+
+# Memory service configuration
+MEMORY_BACKEND=rest
+MEMORY_ENDPOINT=http://localhost:8000
+MEMORY_REDIS_URL=redis://localhost:6379/0
+MEMORY_FILE_PATH=memory.jsonl
+MEMORY_EMBED_FIELD=text
+
+# Authentication
+API_AUTH_KEY=

--- a/README.md
+++ b/README.md
@@ -421,7 +421,9 @@ process environment and a dotenv file.  Set ``ENV`` to choose which file is
 loaded (`.env` for ``ENV=prod`` or `.env.<ENV>` otherwise).  You can also set
 ``ENV_FILE`` to point at an explicit path.  The most common variables are
 summarised below. Any of them can be set in your shell or added to the chosen
-dotenv file before running the orchestrator or tests.
+dotenv file before running the orchestrator or tests. An example file named
+``.env.example`` at the repository root lists these variables—copy it to
+``.env`` and adjust the values for local development.
 
 | Variable | Purpose |
 |----------|---------|


### PR DESCRIPTION
## Summary
- add `.env.example` listing typical variables like `OPENAI_API_KEY` and `API_AUTH_KEY`
- reference the example file in the environment variable section of the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879e74f8d84832b88bf255741de71fa