### PR TITLE
Add async context manager to SolutionOrchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ You can exercise the orchestrator with a single team using a few lines of Python
 ```python
 from src.solution_orchestrator import SolutionOrchestrator
 
-orch = SolutionOrchestrator({"sales": "src/teams/sales_team_full.json"})
-orch.handle_event("sales", {"type": "lead_capture", "payload": {"email": "alice@example.com"}})
+async def demo():
+    async with SolutionOrchestrator({"sales": "src/teams/sales_team_full.json"}) as orch:
+        await orch.handle_event("sales", {"type": "lead_capture", "payload": {"email": "alice@example.com"}})
 ```
 
 ---

--- a/src/api.py
+++ b/src/api.py
@@ -85,6 +85,14 @@ def create_app(orchestrator: SolutionOrchestrator | None = None) -> FastAPI:
     db.init_db()
     orch = orchestrator or SolutionOrchestrator({})
 
+    @app.on_event("startup")
+    async def _startup() -> None:
+        await orch.__aenter__()
+
+    @app.on_event("shutdown")
+    async def _shutdown() -> None:
+        await orch.__aexit__(None, None, None)
+
     origins = (
         [o.strip() for o in settings.ALLOWED_ORIGINS.split(",")]
         if settings.ALLOWED_ORIGINS and settings.ALLOWED_ORIGINS != "*"

--- a/src/cli.py
+++ b/src/cli.py
@@ -106,16 +106,19 @@ def cmd_start(args: argparse.Namespace) -> None:
     orch = SolutionOrchestrator(teams)
 
     async def _run() -> None:
-        server = await asyncio.start_server(
-            lambda r, w: _handle_client(r, w, orch), host=args.host, port=args.port
-        )
-        addr = server.sockets[0].getsockname()
-        print(f"Listening on {addr[0]}:{addr[1]}", file=sys.stderr)
-        async with server:
-            try:
-                await server.serve_forever()
-            except asyncio.CancelledError:  # pragma: no cover - server shutdown
-                pass
+        async with orch:
+            server = await asyncio.start_server(
+                lambda r, w: _handle_client(r, w, orch),
+                host=args.host,
+                port=args.port,
+            )
+            addr = server.sockets[0].getsockname()
+            print(f"Listening on {addr[0]}:{addr[1]}", file=sys.stderr)
+            async with server:
+                try:
+                    await server.serve_forever()
+                except asyncio.CancelledError:  # pragma: no cover - server shutdown
+                    pass
 
     try:
         asyncio.run(_run())

--- a/src/solution_orchestrator.py
+++ b/src/solution_orchestrator.py
@@ -149,3 +149,19 @@ class SolutionOrchestrator:
 
         engine = GraphWorkflowEngine(definition)
         return engine.run(self)
+
+    # ------------------------------------------------------------------
+    # Async context manager implementation
+    # ------------------------------------------------------------------
+    async def __aenter__(self) -> "SolutionOrchestrator":
+        """Return ``self`` so the orchestrator can be used with ``async with``."""
+
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        """Release resources such as async memory services on shutdown."""
+
+        for team in self.teams.values():
+            mem = getattr(team, "memory", None)
+            if hasattr(mem, "aclose"):
+                await mem.aclose()

--- a/tests/test_solution_orchestrator.py
+++ b/tests/test_solution_orchestrator.py
@@ -8,6 +8,7 @@ import pytest
 
 from src.solution_orchestrator import SolutionOrchestrator
 from src.agents.base_agent import BaseAgent
+from src.memory_service.base import BaseMemoryService
 
 
 class DummyAgentA(BaseAgent):
@@ -100,3 +101,38 @@ def test_solution_orchestrator_concurrent(tmp_path):
 
     assert res_a["result"]["handled_by"] == "A"
     assert res_b["result"]["handled_by"] == "B"
+
+
+class DummyMemory(BaseMemoryService):
+    """Minimal async memory service used for context manager tests."""
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    def store(self, key: str, payload: dict) -> bool:  # pragma: no cover - unused
+        return True
+
+    def fetch(self, key: str, top_k: int = 5) -> list[dict]:  # pragma: no cover - unused
+        return []
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+def test_async_context_closes_memory(tmp_path):
+    team = _write_team(tmp_path, "dummy_agent_a")
+
+    mod_a = types.ModuleType("src.agents.dummy_agent_a")
+    mod_a.DummyAgentA = DummyAgentA
+    sys.modules["src.agents.dummy_agent_a"] = mod_a
+
+    orch = SolutionOrchestrator({"A": str(team)})
+    mem = DummyMemory()
+    orch.teams["A"].memory = mem
+
+    async def _run():
+        async with orch:
+            pass
+
+    asyncio.run(_run())
+    assert mem.closed is True


### PR DESCRIPTION
## Summary
- implement asynchronous context management in SolutionOrchestrator
- update CLI and API startup sequences to use `async with`
- demonstrate usage in README example
- ensure team memory services are closed via new tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879e754ee70832b91ae055841af326e