### PR TITLE
Improve CLI network error handling with timeout support

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ orchestrator and send events from another shell:
 # launch the orchestrator (listens on localhost:8765)
 brookside-cli start sales=src/teams/sales_team_full.json
 
-# dispatch an event
+# dispatch an event (5s timeout by default)
 brookside-cli send --team sales --event '{"type": "lead_capture", "payload": {"email": "alice@example.com"}}'
 
 # view latest statuses
@@ -254,6 +254,9 @@ brookside-cli assist "handle new inventory"
 # run an integration pipeline
 brookside-cli run-integration CRM_to_ERP_Contacts --team sales
 ```
+
+Use the optional `--timeout` flag with `send`, `status` and `run-integration`
+to override the 5 second default when connecting to the orchestrator.
 
 A helper utility ``brookside-assistant`` extracts campaign parameters from free
 text. Provide a description on the command line or via stdin and it returns a

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -20,12 +20,14 @@ The command prints the address on `stderr` and blocks until interrupted.
 ## send
 
 Dispatch an event to the running orchestrator. Provide the target team name with `--team` and the event payload as JSON via `--event` or standard input.
+Use `--timeout` to adjust the network timeout (default 5 seconds).
 
 ```bash
 brookside-cli send --team sales --event '{"type": "lead_capture", "payload": {"email": "alice@example.com"}}'
 ```
 
 Use `--host` and `--port` if the server is running on another address.
+The `--timeout` flag is also honoured by `status` and `run-integration`.
 
 ## status
 
@@ -71,7 +73,9 @@ the JSON result.
 
 ## Troubleshooting
 
-- **Connection refused** – `send` or `status` may fail with `[Errno 111] Connection refused` if the server is not running or the wrong `--host`/`--port` is used.
+- **Connection refused** – If the server is not running or the wrong address is used, commands print `Failed to connect to HOST:PORT`.
+- **Timeouts** – Operations abort with `Timed out waiting for server response` when the orchestrator does not reply within the configured `--timeout` value.
 - **Invalid JSON event** – If the payload passed to `--event` cannot be parsed, the command exits with `Invalid JSON event`.
+- **Invalid response** – When the server sends malformed JSON, the CLI reports `Invalid JSON response`.
 - **Schema errors** – `validate-team` prints `{"valid": false}` when the file does not match the schema. Inspect the accompanying `error` field for details.
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -123,18 +123,67 @@ def cmd_start(args: argparse.Namespace) -> None:
         pass
 
 
-def _send_payload(host: str, port: int, payload: dict) -> dict:
-    """Send ``payload`` to the orchestrator server and return the JSON reply."""
+def _send_payload(host: str, port: int, payload: dict, timeout: float = 5.0) -> dict:
+    """Send ``payload`` to the orchestrator and return the JSON reply.
+
+    Parameters
+    ----------
+    host:
+        Server host name or IP address.
+    port:
+        Server port number.
+    payload:
+        JSON-serialisable object describing the command to execute.
+    timeout:
+        Optional timeout in seconds for both connecting and reading.  Defaults
+        to ``5`` seconds.
+
+    Returns
+    -------
+    dict
+        Parsed JSON response from the server.
+
+    Raises
+    ------
+    SystemExit
+        If the connection fails, times out or the response cannot be decoded
+        as JSON.  The exit message is a user friendly error description.
+    """
+
     data = json.dumps(payload).encode() + b"\n"
-    with socket.create_connection((host, port)) as sock:
-        sock.sendall(data)
-        resp = b""
-        while not resp.endswith(b"\n"):
-            chunk = sock.recv(4096)
-            if not chunk:
-                break
-            resp += chunk
-    return json.loads(resp.decode())
+
+    try:
+        # ``create_connection`` also accepts a timeout which covers DNS lookup
+        # and the initial TCP handshake.  ``sock.settimeout`` below applies to
+        # subsequent send/recv operations.
+        with socket.create_connection((host, port), timeout=timeout) as sock:
+            sock.settimeout(timeout)
+            try:
+                sock.sendall(data)
+                resp = b""
+                while not resp.endswith(b"\n"):
+                    chunk = sock.recv(4096)
+                    if not chunk:
+                        break
+                    resp += chunk
+            except socket.timeout as exc:
+                raise SystemExit(
+                    f"Timed out waiting for server response after {timeout}s"
+                ) from exc
+    except ConnectionRefusedError as exc:
+        raise SystemExit(f"Failed to connect to {host}:{port}") from exc
+    except socket.timeout as exc:
+        raise SystemExit(
+            f"Connection to {host}:{port} timed out after {timeout}s"
+        ) from exc
+    except OSError as exc:
+        # Other networking errors (e.g. unreachable network)
+        raise SystemExit(str(exc)) from exc
+
+    try:
+        return json.loads(resp.decode())
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Invalid JSON response: {exc}") from exc
 
 
 def cmd_send(args: argparse.Namespace) -> None:
@@ -154,14 +203,14 @@ def cmd_send(args: argparse.Namespace) -> None:
         raise SystemExit("--team is required")
 
     payload = {"cmd": "send", "team": args.team, "event": event}
-    resp = _send_payload(args.host, args.port, payload)
+    resp = _send_payload(args.host, args.port, payload, timeout=args.timeout)
     print(json.dumps(resp))
 
 
 def cmd_status(args: argparse.Namespace) -> None:
     """Retrieve team statuses from the orchestrator."""
     payload = {"cmd": "status"}
-    resp = _send_payload(args.host, args.port, payload)
+    resp = _send_payload(args.host, args.port, payload, timeout=args.timeout)
     print(json.dumps(resp))
 
 
@@ -206,7 +255,7 @@ def cmd_run_integration(args: argparse.Namespace) -> None:
         raise SystemExit("--team is required")
     event = {"type": "integration_request", "payload": {"name": args.name}}
     payload = {"cmd": "send", "team": args.team, "event": event}
-    resp = _send_payload(args.host, args.port, payload)
+    resp = _send_payload(args.host, args.port, payload, timeout=args.timeout)
     print(json.dumps(resp))
 
 
@@ -235,6 +284,12 @@ def build_parser() -> argparse.ArgumentParser:
     send_p.add_argument("--event", required=False, help="Event JSON string")
     send_p.add_argument("--host", default=DEFAULT_HOST, help="Server address")
     send_p.add_argument("--port", type=int, default=DEFAULT_PORT, help="Server port")
+    send_p.add_argument(
+        "--timeout",
+        type=float,
+        default=5.0,
+        help="Connection timeout in seconds (default: 5)",
+    )
     send_p.set_defaults(func=cmd_send)
 
     run_int = sub.add_parser(
@@ -244,6 +299,12 @@ def build_parser() -> argparse.ArgumentParser:
     run_int.add_argument("--team", required=False, help="Target team name")
     run_int.add_argument("--host", default=DEFAULT_HOST, help="Server address")
     run_int.add_argument("--port", type=int, default=DEFAULT_PORT, help="Server port")
+    run_int.add_argument(
+        "--timeout",
+        type=float,
+        default=5.0,
+        help="Connection timeout in seconds (default: 5)",
+    )
     run_int.set_defaults(func=cmd_run_integration)
 
     assist_p = sub.add_parser(
@@ -256,6 +317,12 @@ def build_parser() -> argparse.ArgumentParser:
     status_p = sub.add_parser("status", help="Fetch latest team statuses")
     status_p.add_argument("--host", default=DEFAULT_HOST, help="Server address")
     status_p.add_argument("--port", type=int, default=DEFAULT_PORT, help="Server port")
+    status_p.add_argument(
+        "--timeout",
+        type=float,
+        default=5.0,
+        help="Connection timeout in seconds (default: 5)",
+    )
     status_p.set_defaults(func=cmd_status)
 
     validate_p = sub.add_parser(


### PR DESCRIPTION
## Summary
- add timeout parameter and robust error handling to `_send_payload`
- expose `--timeout` option on CLI commands
- document the timeout flag in README and CLI reference
- test connection errors, timeouts and malformed responses

## Testing
- `pytest -q`
- `black src/cli.py tests/test_cli.py`
- `flake8 src/cli.py tests/test_cli.py` *(fails: command not found)*
- `mypy src/cli.py tests/test_cli.py` *(fails: unrecognized arguments --ignore-errors)*

------
https://chatgpt.com/codex/tasks/task_e_6879e75840a8832b8f37f24e58bb7b71