### PR TITLE
Validate workflow payloads

### DIFF
--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -43,7 +43,9 @@ For more complex flows you can describe nodes and edges explicitly. The
 [`frontend`](../frontend) editor exports a graph conforming to the JSON schema in
 [`workflow_schema.json`](workflow_schema.json). Each node represents an `agent`
 or `tool` and edges model the execution order. Persist the file via the `/workflows`
-endpoint and load it later with `GraphWorkflowDefinition.from_file()`.
+endpoint and load it later with `GraphWorkflowDefinition.from_file()`. Incoming
+definitions are validated against the schema using ``jsonschema`` and an HTTP
+``400`` error is returned when validation fails.
 
 ### Executing Graph Workflows
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -231,6 +231,16 @@ def test_workflow_endpoints(tmp_path):
         )
         assert code == 201
 
+        bad = {"name": "bad", "nodes": [{}], "edges": []}
+        code, body = _http_post(
+            f"http://127.0.0.1:{port}/workflows",
+            bad,
+            headers={"X-API-Key": "secret"},
+        )
+        assert code == 400
+        err = json.loads(body)
+        assert "invalid workflow" in err.get("detail", "")
+
         code, body = _http_get(
             f"http://127.0.0.1:{port}/workflows/demo",
             headers={"X-API-Key": "secret"},


### PR DESCRIPTION
## Summary
- validate POST /workflows payloads with docs/workflow_schema.json
- return HTTP 400 with details when workflow validation fails
- document validation step in docs/workflows.md
- test valid and invalid workflow submissions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6879e75b7654832b8ea60a0bf672ccf1