### PR TITLE
Add runtime team management

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,16 @@ curl -H "X-API-Key: mysecret" \
      -d '{"type": "lead_capture", "payload": {"email": "alice@example.com"}}'
 ```
 
+Add a team at runtime or remove one again:
+
+```bash
+curl -H "X-API-Key: mysecret" \
+     -X POST http://localhost:8000/teams \
+     -d '{"name": "marketing", "path": "src/teams/marketing_team.json"}'
+
+curl -H "X-API-Key: mysecret" -X DELETE http://localhost:8000/teams/marketing
+```
+
 Fetch the latest status:
 
 ```bash

--- a/src/solution_orchestrator.py
+++ b/src/solution_orchestrator.py
@@ -118,6 +118,46 @@ class SolutionOrchestrator:
             return []
         return self.activity_logger.tail(limit)
 
+    def add_team(self, name: str, path: str) -> None:
+        """Load ``path`` and register a new team named ``name``.
+
+        Parameters
+        ----------
+        name:
+            Identifier used when routing events to this team.
+        path:
+            Filesystem path to the JSON/YAML team configuration.
+
+        Raises
+        ------
+        ValueError
+            If ``name`` is already present in :attr:`teams`.
+        """
+
+        if name in self.teams:
+            raise ValueError(f"Team '{name}' already exists")
+        self.teams[name] = TeamOrchestrator(Path(path))
+
+    def remove_team(self, name: str) -> None:
+        """Remove ``name`` from the orchestrator.
+
+        Parameters
+        ----------
+        name:
+            Registered team identifier.
+
+        Raises
+        ------
+        ValueError
+            If ``name`` is not a known team.
+        """
+
+        if name not in self.teams:
+            raise ValueError(f"Team '{name}' not found")
+        self.teams.pop(name)
+        self.status.pop(name, None)
+        self._subscribers.pop(name, None)
+
     def execute_goal(self, goal: str) -> Dict[str, Any]:
         """Run the planner for the given ``goal``.
 


### PR DESCRIPTION
## Summary
- allow adding/removing teams at runtime
- expose POST `/teams` and DELETE `/teams/{name}` HTTP endpoints
- document new endpoints in README
- test API team management
- test SolutionOrchestrator team registration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6879e75d833c832bb2599591ca72466e