### PR TITLE
Document and test email plugin registration

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -76,7 +76,8 @@ Utility classes can be plugged in using the same mechanism. Implement a
 ``BaseToolPlugin`` subclass under ``src/plugins`` or distribute it via an entry
 point in the ``brookside.plugins`` group. At runtime
 ``src.utils.plugin_loader.load_plugin`` resolves the class so it can be
-instantiated by agents or orchestrators.
+instantiated by agents or orchestrators. For example, to expose the
+``EmailPlugin`` via entry points add the following to ``setup.cfg``:
 
 ```ini
 [options.entry_points]
@@ -84,7 +85,8 @@ brookside.plugins =
     email = src.plugins.email_plugin:EmailPlugin
 ```
 
-Plugins placed directly in ``src/plugins/`` do not require registration and are
+Once installed, ``load_plugin('email')`` will return ``EmailPlugin``. Plugins
+placed directly in ``src/plugins/`` do not require registration and are
 automatically importable by name.
 
 You can also resolve components manually using the helper in

--- a/tests/test_load_plugin.py
+++ b/tests/test_load_plugin.py
@@ -56,3 +56,21 @@ def test_load_plugin_invalid_entry_point(monkeypatch):
 
     with pytest.raises(TypeError):
         load_plugin("bad")
+
+
+def test_load_email_plugin_via_entry_point(monkeypatch):
+    """load_plugin('email') should resolve the EmailPlugin class."""
+
+    ep = importlib.metadata.EntryPoint(
+        "email", "src.plugins.email_plugin:EmailPlugin", "brookside.plugins"
+    )
+    monkeypatch.setattr(importlib.metadata, "entry_points", lambda group=None: [ep])
+    monkeypatch.setattr(
+        "src.utils.plugin_loader.import_module",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("import_module called")),
+    )
+
+    from src.plugins.email_plugin import EmailPlugin
+
+    cls = load_plugin("email")
+    assert cls is EmailPlugin


### PR DESCRIPTION
## Summary
- document how to register `EmailPlugin` in `setup.cfg` and load it
- add unit test ensuring `load_plugin('email')` resolves to `EmailPlugin`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879e76119dc832bb01b1d8ebb6ff71d