### PR TITLE
Add worker queue to orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,14 @@ You can exercise the orchestrator with a single team using a few lines of Python
 
 ```python
 from src.solution_orchestrator import SolutionOrchestrator
+import asyncio
 
 orch = SolutionOrchestrator({"sales": "src/teams/sales_team_full.json"})
-orch.handle_event("sales", {"type": "lead_capture", "payload": {"email": "alice@example.com"}})
+asyncio.run(
+    orch.enqueue_event(
+        "sales", {"type": "lead_capture", "payload": {"email": "alice@example.com"}}
+    )
+)
 ```
 
 ---
@@ -113,7 +118,9 @@ orch = SolutionOrchestrator({
 #     "sales": "src/teams/sales_team_full.yaml",
 #     "operations": "src/teams/operations_team.yaml",
 # })
-orch.handle_event("sales", {"type": "lead_capture", "payload": {}})
+asyncio.run(
+    orch.enqueue_event("sales", {"type": "lead_capture", "payload": {}})
+)
 ```
 
 Teams can report progress upward via `orch.report_status(team, status)`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -112,7 +112,7 @@ At this point all AutoGen agents are live and waiting for events. Teams remain a
 
 ### SolutionOrchestrator
 
-`src.solution_orchestrator.SolutionOrchestrator` manages multiple `TeamOrchestrator` instances.  It routes events to a named team via the async `handle_event(team, event)` method and records the results.
+`src.solution_orchestrator.SolutionOrchestrator` manages multiple `TeamOrchestrator` instances.  It routes events to a named team via the async `handle_event(team, event)` method and records the results. For higher throughput, events may be queued with `enqueue_event()` which are processed by a pool of worker tasks limited by `max_workers`.
 
 ## AutoGen Agents and Providers
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -14,6 +14,7 @@ Arguments:
 
 - `--host` – Bind address. Defaults to `127.0.0.1`.
 - `--port` – Port to listen on. Defaults to `8765`.
+- `--workers` – Maximum number of concurrent events. Defaults to `5`.
 
 The command prints the address on `stderr` and blocks until interrupted.
 

--- a/tests/test_worker_queue.py
+++ b/tests/test_worker_queue.py
@@ -1,0 +1,69 @@
+import asyncio
+import json
+import sys
+import types
+import asyncio
+from pathlib import Path
+
+from src.solution_orchestrator import SolutionOrchestrator
+from src.agents.base_agent import BaseAgent
+
+
+class SlowAgent(BaseAgent):
+    async def run(self, payload):
+        await asyncio.sleep(0.01)
+        return payload
+
+
+def _write_team(tmp_path: Path) -> Path:
+    cfg = {
+        "provider": "autogen.agentchat.teams.RoundRobinGroupChat",
+        "responsibilities": ["slow_agent"],
+        "config": {"participants": [{"config": {"name": "slow_agent"}}]},
+    }
+    path = tmp_path / "team.json"
+    path.write_text(json.dumps(cfg))
+    return path
+
+
+def test_queue_limits_concurrency(tmp_path):
+    team_cfg = _write_team(tmp_path)
+    mod = types.ModuleType("src.agents.slow_agent")
+    mod.SlowAgent = SlowAgent
+    sys.modules["src.agents.slow_agent"] = mod
+
+    orch = SolutionOrchestrator({"demo": str(team_cfg)}, max_workers=2)
+
+    active = 0
+    max_seen = 0
+    lock = asyncio.Lock()
+
+    original_run = SlowAgent.run
+
+    async def wrapped(self, payload):
+        nonlocal active, max_seen
+        async with lock:
+            active += 1
+            if active > max_seen:
+                max_seen = active
+        try:
+            return await original_run(self, payload)
+        finally:
+            async with lock:
+                active -= 1
+
+    SlowAgent.run = wrapped
+
+    async def _run():
+        return await asyncio.gather(
+            *[
+                orch.enqueue_event("demo", {"type": "slow_agent", "payload": {"i": i}})
+                for i in range(5)
+            ]
+        )
+
+    results = asyncio.run(_run())
+
+    assert len(results) == 5
+    assert max_seen <= 2
+


### PR DESCRIPTION
## Summary
- introduce max_workers and a worker queue in `SolutionOrchestrator`
- update CLI/API to enqueue events rather than handle directly
- document new CLI `--workers` option and usage
- describe queueing in architecture docs
- refresh README examples
- add stress test verifying concurrency limit

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879e7703538832bb44e6c4e35569209