### PR TITLE
Add configurable log file path and plain-text mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,8 @@ dotenv file before running the orchestrator or tests.
 | `PROMETHEUS_PUSHGATEWAY` | Metrics aggregation endpoint |
 | `VISITOR_ANALYTICS_URL` / `VISITOR_ANALYTICS_KEY` | Visitor tracking analytics configuration |
 | `MLS_API_URL` / `MLS_API_KEY` | Real estate data feed |
+| `LOG_FILE` | Write logs to this file instead of `stdout` |
+| `LOG_PLAIN` | Emit human readable logs when set to `true` or `1` |
 
 For an exhaustive description of all variables see
 [docs/environment.md](docs/environment.md).

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -21,3 +21,17 @@ message:
 ```json
 {"timestamp": "2024-01-01T00:00:00Z", "level": "INFO", "name": "demo", "message": "Started"}
 ```
+
+Additional environment variables allow customising the output location and
+format:
+
+* ``LOG_FILE`` – path to a file where logs should be written. When set,
+  ``setup_logging`` writes to this file instead of ``stdout``.
+* ``LOG_PLAIN`` – when set to ``true`` or ``1`` the logger emits human readable
+  text rather than JSON.
+
+These can also be specified via parameters:
+
+```python
+setup_logging(file_path="/tmp/app.log", plain_text=True)
+```

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 from io import StringIO
 
 from src.utils.logging_config import setup_logging
@@ -36,3 +37,47 @@ def test_setup_logging_idempotent():
     # only first stream should have data
     assert stream1.getvalue()
     assert not stream2.getvalue()
+
+
+def test_plain_text_formatting():
+    root = logging.getLogger()
+    for h in root.handlers[:]:
+        root.removeHandler(h)
+    stream = StringIO()
+    setup_logging(stream=stream, plain_text=True)
+    logger = logging.getLogger("plain")
+    logger.warning("simple")
+    line = stream.getvalue().strip()
+    pattern = (
+        r"^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}\] \[WARNING\] plain: simple$"
+    )
+    assert re.match(pattern, line), f"Unexpected log format: {line}"
+
+
+def test_file_output_json(tmp_path):
+    root = logging.getLogger()
+    for h in root.handlers[:]:
+        root.removeHandler(h)
+    log_file = tmp_path / "out.log"
+    setup_logging(file_path=str(log_file))
+    logger = logging.getLogger("filetest")
+    logger.error("boom")
+    data = json.loads(log_file.read_text().strip())
+    assert data["message"] == "boom"
+    assert data["level"] == "ERROR"
+    assert data["name"] == "filetest"
+
+
+def test_env_vars(monkeypatch, tmp_path):
+    root = logging.getLogger()
+    for h in root.handlers[:]:
+        root.removeHandler(h)
+    log_file = tmp_path / "env.log"
+    monkeypatch.setenv("LOG_FILE", str(log_file))
+    monkeypatch.setenv("LOG_PLAIN", "true")
+    setup_logging()
+    logger = logging.getLogger("env")
+    logger.info("hi")
+    content = log_file.read_text().strip()
+    assert "env: hi" in content
+    assert not content.startswith("{")


### PR DESCRIPTION
## Summary
- support `file_path` and `plain_text` options in `setup_logging`
- document LOG_FILE and LOG_PLAIN environment variables
- list the new variables in README
- cover plain-text and file output behaviour in tests

## Testing
- `pytest tests/test_logging_config.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879e76b0ab8832bac297d0fcf7fc955