### PR TITLE
Add shared team mapping parser

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -28,6 +28,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
 from .utils.logging_config import setup_logging
+from .utils.team_mapping import parse_team_mapping
 
 
 class Event(BaseModel):
@@ -188,16 +189,10 @@ if __name__ == "__main__":  # pragma: no cover - manual execution
     import sys
     import uvicorn
 
-    def _parse_team_mapping(pairs: list[str]) -> dict[str, str]:
-        mapping: dict[str, str] = {}
-        for pair in pairs:
-            if "=" not in pair:
-                raise SystemExit(f"Invalid team spec '{pair}'. Use NAME=PATH")
-            name, path = pair.split("=", 1)
-            mapping[name] = path
-        return mapping
-
-    teams = _parse_team_mapping(sys.argv[1:])
+    try:
+        teams = parse_team_mapping(sys.argv[1:])
+    except ValueError as exc:
+        raise SystemExit(str(exc))
     orch = SolutionOrchestrator(teams)
     app = create_app(orch)
     setup_logging()

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -2,5 +2,6 @@
 
 from .activity_logger import ActivityLogger
 from .logging_config import setup_logging
+from .team_mapping import parse_team_mapping
 
-__all__ = ["setup_logging", "ActivityLogger"]
+__all__ = ["setup_logging", "ActivityLogger", "parse_team_mapping"]

--- a/src/utils/team_mapping.py
+++ b/src/utils/team_mapping.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+"""Utilities for handling team configuration mappings."""
+
+from typing import Iterable, Dict
+
+
+def parse_team_mapping(pairs: Iterable[str]) -> Dict[str, str]:
+    """Return mapping of team names to config paths.
+
+    Parameters
+    ----------
+    pairs:
+        Iterable of strings in the format ``NAME=PATH``. ``NAME`` is the
+        identifier for the team and ``PATH`` points to its JSON configuration
+        file.
+
+    Returns
+    -------
+    dict[str, str]
+        Mapping of team names to configuration file paths.
+
+    Raises
+    ------
+    ValueError
+        If any element of ``pairs`` does not contain an ``=`` separator.
+
+    Examples
+    --------
+    >>> parse_team_mapping(["sales=src/teams/sales_team.json"])
+    {'sales': 'src/teams/sales_team.json'}
+    """
+
+    mapping: Dict[str, str] = {}
+    for pair in pairs:
+        if "=" not in pair:
+            raise ValueError(f"Invalid team spec '{pair}'. Use NAME=PATH")
+        name, path = pair.split("=", 1)
+        mapping[name] = path
+    return mapping

--- a/tests/test_team_mapping.py
+++ b/tests/test_team_mapping.py
@@ -1,0 +1,23 @@
+from src.utils.team_mapping import parse_team_mapping
+import pytest
+
+
+def test_parse_team_mapping_basic():
+    pairs = ["sales=teams/sales.json", "ops=teams/ops.json"]
+    result = parse_team_mapping(pairs)
+    assert result == {
+        "sales": "teams/sales.json",
+        "ops": "teams/ops.json",
+    }
+
+
+def test_parse_team_mapping_allows_overrides():
+    pairs = ["demo=one.json", "demo=two.json"]
+    result = parse_team_mapping(pairs)
+    assert result == {"demo": "two.json"}
+
+
+@pytest.mark.parametrize("spec", ["foo"])
+def test_parse_team_mapping_invalid(spec):
+    with pytest.raises(ValueError):
+        parse_team_mapping([spec])


### PR DESCRIPTION
## Summary
- centralize NAME=PATH parsing logic in `src/utils/team_mapping.py`
- use new helper in CLI and API to remove duplicated code
- expose helper from `src/utils` package
- test normal/error cases for team mapping

## Testing
- `black src/utils/team_mapping.py src/utils/__init__.py src/cli.py src/api.py tests/test_team_mapping.py`
- `pytest -q`
- `mypy .` *(fails: Missing type parameters for generic type "Queue")*
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879e778a9b4832b8a5a7a102d4acb94