### PR TITLE
Add graceful shutdown for orchestrators

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,13 @@ You can exercise the orchestrator with a single team using a few lines of Python
 from src.solution_orchestrator import SolutionOrchestrator
 
 orch = SolutionOrchestrator({"sales": "src/teams/sales_team_full.json"})
-orch.handle_event("sales", {"type": "lead_capture", "payload": {"email": "alice@example.com"}})
+try:
+    orch.handle_event(
+        "sales",
+        {"type": "lead_capture", "payload": {"email": "alice@example.com"}},
+    )
+finally:
+    orch.close()
 ```
 
 ---

--- a/src/api.py
+++ b/src/api.py
@@ -179,6 +179,10 @@ def create_app(orchestrator: SolutionOrchestrator | None = None) -> FastAPI:
             raise HTTPException(status_code=404, detail="unknown workflow")
         return json.loads(path.read_text())
 
+    @app.on_event("shutdown")
+    async def _shutdown() -> None:
+        await orch.aclose()
+
     return app
 
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -116,6 +116,8 @@ def cmd_start(args: argparse.Namespace) -> None:
                 await server.serve_forever()
             except asyncio.CancelledError:  # pragma: no cover - server shutdown
                 pass
+            finally:
+                await orch.aclose()
 
     try:
         asyncio.run(_run())

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -200,3 +200,15 @@ class Orchestrator(BaseOrchestrator):
     async def monthly_tick(self) -> None:
         """Emit the RevOps analysis cron event."""
         await run_maybe_async(self.bus.publish, "RevOps.Analyze", {"tenant_id": "demo"})
+
+    # --- shutdown helpers -------------------------------------------------
+
+    async def aclose(self) -> None:
+        """Release resources held by the orchestrator."""
+        if hasattr(self.memory, "aclose"):
+            await self.memory.aclose()
+
+    def close(self) -> None:
+        """Synchronous wrapper around :meth:`aclose`."""
+        if hasattr(self.memory, "aclose"):
+            run_sync(self.memory.aclose())

--- a/src/solution_orchestrator.py
+++ b/src/solution_orchestrator.py
@@ -149,3 +149,18 @@ class SolutionOrchestrator:
 
         engine = GraphWorkflowEngine(definition)
         return engine.run(self)
+
+    # --- shutdown helpers -------------------------------------------------
+
+    async def aclose(self) -> None:
+        """Close resources on all managed teams."""
+        for orch in self.teams.values():
+            mem = getattr(orch, "memory", None)
+            if mem and hasattr(mem, "aclose"):
+                await mem.aclose()
+
+    def close(self) -> None:
+        """Synchronous wrapper around :meth:`aclose`."""
+        from agentic_core import run_sync
+
+        run_sync(self.aclose())

--- a/tests/test_orchestrator_close.py
+++ b/tests/test_orchestrator_close.py
@@ -1,0 +1,75 @@
+import types
+import sys
+
+import pytest
+
+from agentic_core import run_sync
+from src.orchestrator import Orchestrator
+from src.solution_orchestrator import SolutionOrchestrator
+from src.memory_service.base import BaseMemoryService
+
+
+class DummyAsyncMemory(BaseMemoryService):
+    def __init__(self):
+        self.closed = False
+
+    async def store(self, key: str, payload: dict) -> bool:  # pragma: no cover - unused
+        return True
+
+    async def fetch(self, key: str, top_k: int = 5):  # pragma: no cover - unused
+        return []
+
+    async def aclose(self):
+        self.closed = True
+
+
+class DummyScheduler:
+    def create_event(self, cid, ev):  # pragma: no cover - stub
+        return {"id": "evt"}
+
+
+@pytest.fixture
+def dummy_memory(monkeypatch):
+    memory = DummyAsyncMemory()
+    monkeypatch.setattr(
+        "src.orchestrator.AsyncRestMemoryService", lambda endpoint: memory
+    )
+    monkeypatch.setattr(
+        "src.tools.scheduler_tool.SchedulerTool", lambda: DummyScheduler()
+    )
+    sys.modules.setdefault(
+        "requests",
+        types.SimpleNamespace(
+            post=lambda *a, **k: types.SimpleNamespace(ok=True, json=lambda: {}),
+            get=lambda *a, **k: types.SimpleNamespace(ok=True, json=lambda: {}),
+        ),
+    )
+    return memory
+
+
+def test_orchestrator_aclose_calls_memory(dummy_memory):
+    orch = Orchestrator(memory_backend="rest_async", memory_endpoint="http://x")
+    run_sync(orch.aclose())
+    assert dummy_memory.closed is True
+
+
+def test_orchestrator_close_sync(dummy_memory):
+    orch = Orchestrator(memory_backend="rest_async", memory_endpoint="http://x")
+    orch.close()
+    assert dummy_memory.closed is True
+
+
+def test_solution_orchestrator_aclose(monkeypatch):
+    mem = DummyAsyncMemory()
+
+    class DummyTeam:
+        def __init__(self):
+            self.memory = mem
+
+        async def handle_event(self, event):  # pragma: no cover - unused
+            return {}
+
+    orch = SolutionOrchestrator({})
+    orch.teams["demo"] = DummyTeam()
+    run_sync(orch.aclose())
+    assert mem.closed is True


### PR DESCRIPTION
## Summary
- add aclose/close helpers on Orchestrator and SolutionOrchestrator
- shutdown async memory on CLI and API exit
- document shutdown in README
- test closing behaviour for AsyncRestMemoryService

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879e77a9f70832bb64568bd1502bcbc