### PR TITLE
Add API_HOST configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,8 +269,14 @@ An HTTP interface is available for programmatic access to the
 `SolutionOrchestrator`. Start the server with your team mapping and an API key:
 
 ```bash
-API_AUTH_KEY=mysecret python -m src.api sales=src/teams/sales_team_full.json
+API_AUTH_KEY=mysecret \ 
+API_HOST=127.0.0.1 python -m src.api sales=src/teams/sales_team_full.json
 ```
+Here as well, `API_HOST` can be changed if you don't want to listen on every
+interface.
+The `API_HOST` variable lets you control which interface uvicorn binds to.
+`API_HOST` overrides the default bind address `0.0.0.0` if you want the server
+accessible on a specific interface.
 
 Send an event using `curl`:
 
@@ -592,8 +598,10 @@ npm run dev:dashboard
 Start the HTTP API with an authentication key and at least one team configuration:
 
 ```bash
-API_AUTH_KEY=mysecret python -m src.api sales=src/teams/sales_team_full.json
+API_AUTH_KEY=mysecret \
+API_HOST=127.0.0.1 python -m src.api sales=src/teams/sales_team_full.json
 ```
+As before, adjust `API_HOST` if the server should listen on a specific address.
 
 Create a `.env` file inside `frontend/dashboard` so the React app can use the same key when
 communicating with the backend:

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -142,5 +142,6 @@ variables documented below.
 - `GOOGLE_TRANSLATE_API_KEY` – Google Translate API key.
 - `CONFIG_PATH` – Path to the orchestrator configuration, defaults to `config/playbook.yaml`.
 - `API_AUTH_KEY` – Token required by the FastAPI server for requests.
+- `API_HOST` – Bind address for the HTTP API, default `0.0.0.0`.
 - `ALLOWED_ORIGINS` – Comma separated list of domains allowed for CORS requests.
 - `SCRAPER_USER_AGENT` – HTTP User-Agent string used by `ScrapingPlugin`.

--- a/src/api.py
+++ b/src/api.py
@@ -184,9 +184,21 @@ def create_app(orchestrator: SolutionOrchestrator | None = None) -> FastAPI:
 
 app = create_app()
 
-if __name__ == "__main__":  # pragma: no cover - manual execution
-    import sys
+def main(argv: list[str] | None = None) -> None:
+    """Start the API server using ``uvicorn``.
+
+    Parameters
+    ----------
+    argv:
+        Optional list of ``TEAM=PATH`` pairs mapping team names to workflow
+        configuration files. When ``None`` the arguments from ``sys.argv[1:]``
+        are used.
+    """
+
     import uvicorn
+
+    if argv is None:
+        argv = sys.argv[1:]
 
     def _parse_team_mapping(pairs: list[str]) -> dict[str, str]:
         mapping: dict[str, str] = {}
@@ -197,10 +209,14 @@ if __name__ == "__main__":  # pragma: no cover - manual execution
             mapping[name] = path
         return mapping
 
-    teams = _parse_team_mapping(sys.argv[1:])
+    teams = _parse_team_mapping(argv)
     orch = SolutionOrchestrator(teams)
     app = create_app(orch)
     setup_logging()
 
     port = int(os.getenv("PORT", "8000"))
-    uvicorn.run(app, host="0.0.0.0", port=port)
+    uvicorn.run(app, host=settings.API_HOST, port=port)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/src/config.py
+++ b/src/config.py
@@ -172,6 +172,7 @@ class Settings(BaseSettings):
     GOOGLE_TRANSLATE_API_KEY: Optional[str] = None
     CONFIG_PATH: str = "config/playbook.yaml"
     API_AUTH_KEY: Optional[str] = None
+    API_HOST: str = "0.0.0.0"
     ALLOWED_ORIGINS: str = "*"
     SCRAPER_USER_AGENT: str = "BrooksideBot/1.0"
 

--- a/tests/test_api_main.py
+++ b/tests/test_api_main.py
@@ -1,0 +1,26 @@
+import sys
+import types
+import src.api as api
+
+
+def test_main_uses_api_host(monkeypatch):
+    """The entrypoint should pass API_HOST to uvicorn."""
+    captured = {}
+
+    def fake_run(app, host=None, port=None):
+        captured['host'] = host
+        captured['port'] = port
+
+    monkeypatch.setitem(sys.modules, 'uvicorn', types.SimpleNamespace(run=fake_run))
+    monkeypatch.setenv('API_HOST', '127.0.0.1')
+    monkeypatch.setenv('PORT', '12345')
+    api.settings.API_HOST = '127.0.0.1'
+    monkeypatch.setattr(api, 'create_app', lambda *a, **k: 'app')
+    monkeypatch.setattr(api, 'SolutionOrchestrator', lambda *a, **k: 'orch')
+    monkeypatch.setattr(api, 'setup_logging', lambda: None)
+
+    api.main([])
+
+    assert captured['host'] == '127.0.0.1'
+    assert captured['port'] == 12345
+


### PR DESCRIPTION
## Summary
- add `API_HOST` environment variable to Settings
- respect `API_HOST` in the API server entrypoint
- explain the new variable in `docs/environment.md` and showcase usage in `README.md`
- test that `main()` passes the configured host to `uvicorn.run`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6879e77c1a18832b9d448263946c8080