### PR TITLE
Add team and event type filters to history API

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,9 @@ automatically on startup and the connection is controlled via
 `DB_CONNECTION_STRING` (defaults to `sqlite:///data.db`). Every processed event
 is written to the `event_history` table. Retrieve past events using the
 `GET /history` endpoint which supports simple pagination via `limit` and
-`offset` query parameters.
+`offset` query parameters. You can also filter the results by `team` and
+`event_type` to view only the events relevant to a specific workflow or
+agent.
 
 ### 🌟 Creating Custom Teams
 

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -66,6 +66,9 @@ variables documented below.
 - `GOOGLE_APPLICATION_CREDENTIALS` – Path to Google service account JSON.
 - `REDIS_URL` – Redis connection string.
 - `DB_CONNECTION_STRING` – Database URL.
+- The `GET /history` endpoint reads from this database and supports
+  `team` and `event_type` query parameters in addition to `limit` and
+  `offset` for filtering stored events.
 - `KAFKA_BOOTSTRAP_SERVERS` – Kafka broker list.
 - `RABBITMQ_URL` – RabbitMQ connection string.
 - `CLOUD_DOCS_API_URL` – Base URL for the cloud document service.

--- a/src/api.py
+++ b/src/api.py
@@ -155,10 +155,23 @@ def create_app(orchestrator: SolutionOrchestrator | None = None) -> FastAPI:
 
     @app.get("/history")
     def get_history(
-        limit: int = 10, offset: int = 0, _=Depends(_auth)
+        limit: int = 10,
+        offset: int = 0,
+        team: str | None = None,
+        event_type: str | None = None,
+        _=Depends(_auth),
     ) -> Dict[str, Any]:
-        """Return persisted event history from the database."""
-        items = db.fetch_history(limit=limit, offset=offset)
+        """Return persisted event history from the database.
+
+        The results can be filtered by ``team`` and ``event_type``. When
+        omitted all events are returned ordered by timestamp.
+        """
+        items = db.fetch_history(
+            limit=limit,
+            offset=offset,
+            team=team,
+            event_type=event_type,
+        )
         return {"history": items}
 
     @app.post("/workflows", status_code=201)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -6,6 +6,15 @@ def test_db_write_and_read(tmp_path):
     settings.DB_CONNECTION_STRING = f"sqlite:///{tmp_path}/t.db"
     db.init_db()
     db.insert_event("demo", "x", {"a": 1}, {"r": 2})
+    db.insert_event("other", "y", {"b": 2}, {"s": 3})
+
     rows = db.fetch_history(limit=10)
+    assert len(rows) == 2
+
+    rows = db.fetch_history(team="demo")
     assert len(rows) == 1
-    assert rows[0]["team"] == "demo"
+    assert rows[0]["event_type"] == "x"
+
+    rows = db.fetch_history(event_type="y")
+    assert len(rows) == 1
+    assert rows[0]["team"] == "other"


### PR DESCRIPTION
## Summary
- extend `db.fetch_history()` with optional `team` and `event_type` filters
- expose the filters via the `/history` endpoint
- update unit tests for the new functionality
- document the new query parameters in `README.md` and `docs/environment.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879e77fd4ac832b9c765e2472c0adaa