### PR TITLE
Add history subcommand to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,9 @@ brookside-cli assist "handle new inventory"
 
 # run an integration pipeline
 brookside-cli run-integration CRM_to_ERP_Contacts --team sales
+
+# show recent event history
+brookside-cli history --limit 5 --team sales
 ```
 
 A helper utility ``brookside-assistant`` extracts campaign parameters from free

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -69,6 +69,21 @@ brookside-cli run-integration CRM_to_ERP_Contacts --team sales
 The command sends an `integration_request` task to the orchestrator and prints
 the JSON result.
 
+## history
+
+Display persisted event history stored in the SQLite database.
+
+```bash
+brookside-cli history --limit 20 --team sales --event-type lead_capture
+```
+
+Arguments:
+
+- `--limit` – maximum number of records to return. Defaults to `10`.
+- `--offset` – number of records to skip before returning results.
+- `--team` – filter results to a specific team.
+- `--event-type` – filter by event type.
+
 ## Troubleshooting
 
 - **Connection refused** – `send` or `status` may fail with `[Errno 111] Connection refused` if the server is not running or the wrong `--host`/`--port` is used.


### PR DESCRIPTION
## Summary
- add optional filters to `fetch_history`
- initialize DB when starting the CLI server
- add `history` subcommand to CLI to view event history
- document new command
- test history command

## Testing
- `pytest -q tests/test_cli.py tests/test_db.py`

------
https://chatgpt.com/codex/tasks/task_e_6879e783b9c0832baae70831ad252d6e