### PR TITLE
Add context manager support for orchestrators

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,11 @@ You can exercise the orchestrator with a single team using a few lines of Python
 ```python
 from src.solution_orchestrator import SolutionOrchestrator
 
-orch = SolutionOrchestrator({"sales": "src/teams/sales_team_full.json"})
-orch.handle_event("sales", {"type": "lead_capture", "payload": {"email": "alice@example.com"}})
+with SolutionOrchestrator({"sales": "src/teams/sales_team_full.json"}) as orch:
+    orch.handle_event_sync(
+        "sales",
+        {"type": "lead_capture", "payload": {"email": "alice@example.com"}},
+    )
 ```
 
 ---

--- a/src/api.py
+++ b/src/api.py
@@ -198,9 +198,9 @@ if __name__ == "__main__":  # pragma: no cover - manual execution
         return mapping
 
     teams = _parse_team_mapping(sys.argv[1:])
-    orch = SolutionOrchestrator(teams)
-    app = create_app(orch)
-    setup_logging()
+    with SolutionOrchestrator(teams) as orch:
+        app = create_app(orch)
+        setup_logging()
 
-    port = int(os.getenv("PORT", "8000"))
-    uvicorn.run(app, host="0.0.0.0", port=port)
+        port = int(os.getenv("PORT", "8000"))
+        uvicorn.run(app, host="0.0.0.0", port=port)

--- a/src/cli.py
+++ b/src/cli.py
@@ -103,19 +103,19 @@ def cmd_start(args: argparse.Namespace) -> None:
     from .solution_orchestrator import SolutionOrchestrator
 
     teams = _parse_team_mapping(tuple(args.teams))
-    orch = SolutionOrchestrator(teams)
 
     async def _run() -> None:
-        server = await asyncio.start_server(
-            lambda r, w: _handle_client(r, w, orch), host=args.host, port=args.port
-        )
-        addr = server.sockets[0].getsockname()
-        print(f"Listening on {addr[0]}:{addr[1]}", file=sys.stderr)
-        async with server:
-            try:
-                await server.serve_forever()
-            except asyncio.CancelledError:  # pragma: no cover - server shutdown
-                pass
+        async with SolutionOrchestrator(teams) as orch:
+            server = await asyncio.start_server(
+                lambda r, w: _handle_client(r, w, orch), host=args.host, port=args.port
+            )
+            addr = server.sockets[0].getsockname()
+            print(f"Listening on {addr[0]}:{addr[1]}", file=sys.stderr)
+            async with server:
+                try:
+                    await server.serve_forever()
+                except asyncio.CancelledError:  # pragma: no cover - server shutdown
+                    pass
 
     try:
         asyncio.run(_run())

--- a/tests/test_orchestrator_context.py
+++ b/tests/test_orchestrator_context.py
@@ -1,0 +1,138 @@
+import asyncio
+import sys
+import types
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+sys.modules.setdefault(
+    "requests",
+    types.SimpleNamespace(
+        post=lambda *a, **k: types.SimpleNamespace(ok=True, json=lambda: {}),
+        get=lambda *a, **k: types.SimpleNamespace(ok=True, json=lambda: {}),
+    ),
+)
+
+from src.orchestrator import Orchestrator
+from src.memory_service.base import BaseMemoryService
+from src.solution_orchestrator import SolutionOrchestrator
+
+
+class _SyncMem(BaseMemoryService):
+    def __init__(self, flag: Dict[str, bool]):
+        self.flag = flag
+
+    def store(self, key: str, payload: Dict[str, Any]) -> bool:
+        return True
+
+    def fetch(self, key: str, top_k: int = 5) -> List[Dict[str, Any]]:
+        return []
+
+    def close(self) -> None:
+        self.flag["closed"] = True
+
+
+class _AsyncMem(BaseMemoryService):
+    def __init__(self, flag: Dict[str, bool]):
+        self.flag = flag
+
+    async def store(self, key: str, payload: Dict[str, Any]) -> bool:
+        return True
+
+    async def fetch(self, key: str, top_k: int = 5) -> List[Dict[str, Any]]:
+        return []
+
+    async def aclose(self) -> None:
+        self.flag["closed"] = True
+
+
+def test_orchestrator_context_manager(monkeypatch):
+    flag = {"closed": False}
+    monkeypatch.setattr(
+        "src.tools.scheduler_tool.SchedulerTool",
+        lambda: types.SimpleNamespace(create_event=lambda cid, ev: {"id": "evt"}),
+    )
+    monkeypatch.setattr("src.orchestrator.RestMemoryService", lambda e: _SyncMem(flag))
+    with Orchestrator("http://m") as orch:
+        assert isinstance(orch.memory, _SyncMem)
+    assert flag["closed"] is True
+
+
+def test_orchestrator_async_context_manager(monkeypatch):
+    flag = {"closed": False}
+    monkeypatch.setattr(
+        "src.tools.scheduler_tool.SchedulerTool",
+        lambda: types.SimpleNamespace(create_event=lambda cid, ev: {"id": "evt"}),
+    )
+    monkeypatch.setattr(
+        "src.orchestrator.AsyncRestMemoryService", lambda e: _AsyncMem(flag)
+    )
+    async def main():
+        async with Orchestrator(memory_backend="rest_async", memory_endpoint="http://m") as orch:
+            assert isinstance(orch.memory, _AsyncMem)
+
+    asyncio.run(main())
+    assert flag["closed"] is True
+
+
+class _Team:
+    def __init__(self, path: str) -> None:
+        self.flag = {}
+
+    async def handle_event(self, event: Dict[str, Any]) -> Dict[str, Any]:
+        return {}
+
+    def close(self) -> None:
+        self.flag["closed"] = True
+
+
+class _AsyncTeam(_Team):
+    async def aclose(self) -> None:
+        self.flag["closed"] = True
+
+
+def test_solution_orchestrator_context_manager(monkeypatch, tmp_path: Path) -> None:
+    path = tmp_path / "team.json"
+    path.write_text("{}")
+    closed = {}
+
+    monkeypatch.setattr(
+        "src.tools.scheduler_tool.SchedulerTool",
+        lambda: types.SimpleNamespace(create_event=lambda cid, ev: {"id": "evt"}),
+    )
+
+    def factory(p: Path) -> _Team:
+        team = _Team(str(p))
+        team.flag = closed
+        return team
+
+    monkeypatch.setattr("src.solution_orchestrator.TeamOrchestrator", factory)
+    with SolutionOrchestrator({"demo": str(path)}) as orch:
+        assert "demo" in orch.teams
+    assert closed.get("closed") is True
+
+
+def test_solution_orchestrator_async_context_manager(monkeypatch, tmp_path: Path) -> None:
+    path = tmp_path / "team.json"
+    path.write_text("{}")
+    closed = {}
+
+    monkeypatch.setattr(
+        "src.tools.scheduler_tool.SchedulerTool",
+        lambda: types.SimpleNamespace(create_event=lambda cid, ev: {"id": "evt"}),
+    )
+
+    def factory(p: Path) -> _AsyncTeam:
+        team = _AsyncTeam(str(p))
+        team.flag = closed
+        return team
+
+    monkeypatch.setattr("src.solution_orchestrator.TeamOrchestrator", factory)
+
+    async def main():
+        async with SolutionOrchestrator({"demo": str(path)}) as orch:
+            assert "demo" in orch.teams
+
+    asyncio.run(main())
+    assert closed.get("closed") is True


### PR DESCRIPTION
## Summary
- implement `__enter__`/`__exit__` and async variants in `Orchestrator` and `SolutionOrchestrator`
- expose `close` and `aclose` helpers for resource cleanup
- update CLI and API scripts to use context managers
- document context manager usage in README
- add tests covering context manager behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6879e78cbc78832ba8440dbc0af219c9