### PR TITLE
Add db history filters tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,9 @@ automatically on startup and the connection is controlled via
 `DB_CONNECTION_STRING` (defaults to `sqlite:///data.db`). Every processed event
 is written to the `event_history` table. Retrieve past events using the
 `GET /history` endpoint which supports simple pagination via `limit` and
-`offset` query parameters.
+`offset` query parameters. Improvement #4 also introduced optional
+`team` and `event_type` filters so dashboards can focus on specific
+workflows.
 
 ### 🌟 Creating Custom Teams
 

--- a/src/db.py
+++ b/src/db.py
@@ -85,16 +85,35 @@ def insert_event(team: str, event_type: str, payload: dict, result: dict) -> Non
         conn.commit()
 
 
-def fetch_history(limit: int = 10, offset: int = 0) -> list[dict]:
-    """Return a list of history records ordered by timestamp descending."""
+def fetch_history(
+    limit: int = 10,
+    offset: int = 0,
+    team: str | None = None,
+    event_type: str | None = None,
+) -> list[dict]:
+    """Return history rows ordered by newest first with optional filtering."""
+
     path = _get_db_path()
+    query = (
+        "SELECT id, team, event_type, payload, result, timestamp\n"
+        "FROM event_history"
+    )
+    clauses: list[str] = []
+    params: list[object] = []
+    if team is not None:
+        clauses.append("team = ?")
+        params.append(team)
+    if event_type is not None:
+        clauses.append("event_type = ?")
+        params.append(event_type)
+    if clauses:
+        query += " WHERE " + " AND ".join(clauses)
+    query += " ORDER BY timestamp DESC LIMIT ? OFFSET ?"
+    params.extend([limit, offset])
+
     with sqlite3.connect(path) as conn:
         conn.row_factory = sqlite3.Row
-        cur = conn.execute(
-            "SELECT id, team, event_type, payload, result, timestamp\n"
-            "FROM event_history ORDER BY datetime(timestamp) DESC LIMIT ? OFFSET ?",
-            (limit, offset),
-        )
+        cur = conn.execute(query, params)
         rows = cur.fetchall()
     history: list[dict] = []
     for row in rows:

--- a/tests/test_db_history.py
+++ b/tests/test_db_history.py
@@ -1,0 +1,59 @@
+import time
+from datetime import datetime
+import json
+import sqlite3
+
+from src import db
+from src.config import settings
+
+
+def _insert_raw(path, team, event_type, ts):
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            "INSERT INTO event_history (team, event_type, payload, result, timestamp) VALUES (?, ?, ?, ?, ?)",
+            (team, event_type, json.dumps({}), json.dumps({}), ts),
+        )
+        conn.commit()
+
+
+def test_history_order_and_pagination(tmp_path):
+    settings.DB_CONNECTION_STRING = f"sqlite:///{tmp_path}/t.db"
+    db.init_db()
+    path = tmp_path / "t.db"
+
+    t1 = datetime.utcnow().isoformat()
+    time.sleep(0.01)
+    t2 = datetime.utcnow().isoformat()
+    time.sleep(0.01)
+    t3 = datetime.utcnow().isoformat()
+
+    _insert_raw(path, "demo", "A", t1)
+    _insert_raw(path, "demo", "B", t2)
+    _insert_raw(path, "other", "C", t3)
+
+    rows = db.fetch_history(limit=10)
+    assert len(rows) == 3
+    assert rows[0]["timestamp"] > rows[1]["timestamp"] >= rows[2]["timestamp"]
+
+    paged = db.fetch_history(limit=1, offset=1)
+    assert len(paged) == 1
+    assert paged[0]["timestamp"] == rows[1]["timestamp"]
+
+
+def test_history_filters(tmp_path):
+    settings.DB_CONNECTION_STRING = f"sqlite:///{tmp_path}/t.db"
+    db.init_db()
+    path = tmp_path / "t.db"
+    _insert_raw(path, "sales", "alpha", datetime.utcnow().isoformat())
+    _insert_raw(path, "marketing", "beta", datetime.utcnow().isoformat())
+    _insert_raw(path, "sales", "beta", datetime.utcnow().isoformat())
+
+    by_team = db.fetch_history(team="sales")
+    assert {r["team"] for r in by_team} == {"sales"}
+
+    by_event = db.fetch_history(event_type="beta")
+    assert {r["event_type"] for r in by_event} == {"beta"}
+
+    combo = db.fetch_history(team="sales", event_type="beta")
+    assert len(combo) == 1
+    assert combo[0]["team"] == "sales" and combo[0]["event_type"] == "beta"


### PR DESCRIPTION
## Summary
- cover the DB history retrieval with new tests
- add optional `team` and `event_type` filters to `db.fetch_history`
- document history filters in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879e789d5ec832ba6d534769d0c94e6