### PR TITLE
Add branching workflow docs and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,9 @@ Available templates:
   # orch.execute_goal("sales_outreach")
   ```
 
+For a branching graph example see
+[docs/workflows.md#branching-logic-and-error-handling](docs/workflows.md#branching-logic-and-error-handling).
+
 ### 🖥️ Command Line Usage
 
 The project exposes a small CLI for running and interacting with the

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -63,3 +63,60 @@ orch.execute_workflow(wf)
 
 ``execute_workflow`` returns a dictionary containing the orchestrator results
 for every node.
+
+### Branching Logic and Error Handling
+
+Complex flows often require conditional or parallel branches. A node may point to
+multiple targets which will all be queued once the source node finishes. The
+example below starts with a ``start`` node that triggers two independent agents
+``a`` and ``b``:
+
+```json
+{
+  "name": "branching_example",
+  "nodes": [
+    {"id": "start", "type": "agent", "label": "Start",
+     "config": {"team": "A", "event": {"type": "dummy_agent_a", "payload": {}}}},
+    {"id": "a", "type": "agent", "label": "A",
+     "config": {"team": "A", "event": {"type": "dummy_agent_a", "payload": {"foo": 1}}}},
+    {"id": "b", "type": "agent", "label": "B",
+     "config": {"team": "B", "event": {"type": "dummy_agent_b", "payload": {"bar": 2}}}}
+  ],
+  "edges": [
+    {"source": "start", "target": "a"},
+    {"source": "start", "target": "b"}
+  ]
+}
+```
+
+The same definition is available in YAML form at
+``src/workflows/examples/branching_graph.yaml``. Load the YAML with
+``yaml.safe_load`` and pass the resulting dictionary to
+``GraphWorkflowDefinition.from_dict``.
+
+Step‑by‑step execution with the orchestrator:
+
+```python
+import json
+import yaml
+from src.solution_orchestrator import SolutionOrchestrator
+from src.workflows.graph import GraphWorkflowDefinition
+
+orch = SolutionOrchestrator({"A": "team_a.json", "B": "team_b.json"})
+wf = GraphWorkflowDefinition.from_file("src/workflows/examples/branching_graph.json")
+# YAML alternative
+# with open("src/workflows/examples/branching_graph.yaml") as fh:
+#     data = yaml.safe_load(fh)
+# wf = GraphWorkflowDefinition.from_dict(data)
+
+result = orch.execute_workflow(wf)
+for entry in result["results"]:
+    print(entry["node"], entry["result"]["status"])
+```
+
+``execute_workflow`` aggregates each node result and returns a dictionary with a
+``status`` field. Invalid graphs (cycles, unknown references) raise
+``ValueError`` during loading. ``GraphWorkflowEngine`` stops iteration by raising
+``StopIteration`` when no nodes remain. Exceptions from
+``handle_event_sync`` propagate to the caller so they can be handled
+application‑side.

--- a/src/workflows/examples/branching_graph.json
+++ b/src/workflows/examples/branching_graph.json
@@ -1,0 +1,36 @@
+{
+  "name": "branching_example",
+  "nodes": [
+    {
+      "id": "start",
+      "type": "agent",
+      "label": "Start",
+      "config": {
+        "team": "A",
+        "event": {"type": "dummy_agent_a", "payload": {}}
+      }
+    },
+    {
+      "id": "a",
+      "type": "agent",
+      "label": "A",
+      "config": {
+        "team": "A",
+        "event": {"type": "dummy_agent_a", "payload": {"foo": 1}}
+      }
+    },
+    {
+      "id": "b",
+      "type": "agent",
+      "label": "B",
+      "config": {
+        "team": "B",
+        "event": {"type": "dummy_agent_b", "payload": {"bar": 2}}
+      }
+    }
+  ],
+  "edges": [
+    {"source": "start", "target": "a"},
+    {"source": "start", "target": "b"}
+  ]
+}

--- a/src/workflows/examples/branching_graph.yaml
+++ b/src/workflows/examples/branching_graph.yaml
@@ -1,0 +1,33 @@
+name: branching_example
+nodes:
+  - id: start
+    type: agent
+    label: Start
+    config:
+      team: A
+      event:
+        type: dummy_agent_a
+        payload: {}
+  - id: a
+    type: agent
+    label: A
+    config:
+      team: A
+      event:
+        type: dummy_agent_a
+        payload:
+          foo: 1
+  - id: b
+    type: agent
+    label: B
+    config:
+      team: B
+      event:
+        type: dummy_agent_b
+        payload:
+          bar: 2
+edges:
+  - source: start
+    target: a
+  - source: start
+    target: b


### PR DESCRIPTION
## Summary
- document branching logic and error handling in `docs/workflows.md`
- link to new section from README
- add example graph workflow in JSON and YAML

## Testing
- `pytest -q`
- ❌ `pre-commit` *(failed: pre-commit not installed and cannot be fetched)*

------
https://chatgpt.com/codex/tasks/task_e_6879e7880b5c832b9fcd3041f93fb36e