### PR TITLE
Expose package version and add test

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ orch = SolutionOrchestrator({"sales": "src/teams/sales_team_full.json"})
 orch.handle_event("sales", {"type": "lead_capture", "payload": {"email": "alice@example.com"}})
 ```
 
+You can inspect the installed package version programmatically:
+
+```python
+import src
+
+print(src.get_version())  # e.g. "1.0.0"
+assert src.get_version() == src.__version__
+```
+
 ---
 
 ## 🔍 What’s Inside

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,48 @@
-"""Minimal agent-based orchestration framework used for unit tests."""
+"""Brookside BI core package.
+
+This module exposes the package version for external callers.  The
+version is read from ``setup.cfg`` so that both the codebase and the
+packaging metadata stay in sync.
+"""
+
+from __future__ import annotations
+
+import configparser
+from pathlib import Path
+
+
+def _load_version() -> str:
+    """Return the version defined in ``setup.cfg``.
+
+    The configuration file lives one directory above ``src``.  Using a
+    lightweight ``configparser`` reader avoids importing
+    ``pkg_resources`` or ``importlib.metadata`` at runtime which keeps
+    the dependency surface minimal while ensuring the value always
+    matches the packaging metadata.
+    """
+
+    cfg_path = Path(__file__).resolve().parents[1] / "setup.cfg"
+    parser = configparser.ConfigParser()
+    parser.read(cfg_path)
+    try:
+        return parser["metadata"]["version"]
+    except KeyError as exc:  # pragma: no cover - defensive programming
+        raise RuntimeError("Malformed setup.cfg, missing [metadata] version") from exc
+
+
+#: Current package version as defined in ``setup.cfg``.
+__version__: str = _load_version()
+
+
+def get_version() -> str:
+    """Return the current package version.
+
+    This helper simply exposes :data:`__version__` for callers that want
+    a function-based API.  It is primarily useful when mocking during
+    tests or when accessed from dynamic import contexts.
+    """
+
+    return __version__
+
+
+__all__ = ["__version__", "get_version"]

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,14 @@
+from configparser import ConfigParser
+from pathlib import Path
+
+import src
+
+
+def test_version_matches_setup_cfg():
+    cfg_path = Path(__file__).resolve().parents[1] / "setup.cfg"
+    parser = ConfigParser()
+    parser.read(cfg_path)
+    expected = parser["metadata"]["version"]
+    assert src.__version__ == expected
+    assert src.get_version() == expected
+


### PR DESCRIPTION
## Summary
- load version from setup.cfg on import
- expose `get_version()` helper
- test the version
- document version helper in README

## Testing
- `pytest tests/test_version.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6879e785dd0c832ba51c229a77882e4c