### PR TITLE
Add Prometheus metrics middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,13 @@ setup_logging()
 
 See [docs/logging.md](docs/logging.md) for details.
 
+## 📊 Metrics
+
+When `PROMETHEUS_PUSHGATEWAY` is set, the API records the number of requests
+and their latencies. A middleware pushes these metrics to the configured
+Prometheus Pushgateway using the lightweight `PrometheusPusher` utility. Read
+[docs/metrics.md](docs/metrics.md) for a full description.
+
 ## 📐 Environment Variables
 
 The system relies on a number of environment variables for API keys and service

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -92,7 +92,8 @@ variables documented below.
 - `DISCORD_WEBHOOK_URL` – Discord webhook.
 
 ## Monitoring & Analytics
-- `PROMETHEUS_PUSHGATEWAY` – Prometheus Pushgateway URL.
+- `PROMETHEUS_PUSHGATEWAY` – Prometheus Pushgateway URL. When defined the API
+  emits request metrics as described in [metrics.md](metrics.md).
 - `GA4_MEASUREMENT_ID` – Google Analytics 4 measurement ID.
 - `GA4_API_SECRET` – Google Analytics API secret.
 - `MIXPANEL_TOKEN` – Mixpanel project token.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,7 @@ Welcome to the documentation for the Brookside BI agentic system.
    memory_service
    environment
    logging
+   metrics
    agents_overview
    workflows
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,21 @@
+# Metrics Collection
+
+Brookside exposes basic Prometheus metrics when the `PROMETHEUS_PUSHGATEWAY`
+environment variable is configured. A lightweight middleware records the total
+number of requests and their latencies and pushes two gauges to the configured
+Pushgateway:
+
+- `api_request_count` – incremented for every request
+- `api_request_latency_seconds` – time taken to handle the request
+
+The middleware is automatically enabled when `PROMETHEUS_PUSHGATEWAY` is a non
+-empty value. When unset, no metrics are pushed and the overhead is zero.
+
+```bash
+export PROMETHEUS_PUSHGATEWAY="http://localhost:9091"
+python -m src.api
+```
+
+Both metrics include the request path and method as labels so you can aggregate
+by endpoint in Prometheus. See the environment variable reference in
+[docs/environment.md](environment.md) for related settings.

--- a/src/api.py
+++ b/src/api.py
@@ -13,6 +13,8 @@ execution as well.
 from pathlib import Path
 import os
 import sys
+import time
+import logging
 
 if __package__ in {None, ""}:  # pragma: no cover - safe for direct execution
     sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
@@ -26,6 +28,35 @@ from fastapi import Depends, FastAPI, Header, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
+from starlette.middleware.base import BaseHTTPMiddleware
+
+
+logger = logging.getLogger(__name__)
+
+from .tools.metrics_tools.prometheus_tool import PrometheusPusher
+
+
+class MetricsMiddleware(BaseHTTPMiddleware):
+    """Record request metrics via ``PrometheusPusher``."""
+
+    def __init__(self, app: FastAPI, job: str = "api") -> None:  # type: ignore[override]
+        super().__init__(app)
+        self.pusher = PrometheusPusher(job=job)
+
+    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        start = time.perf_counter()
+        response = await call_next(request)
+        duration = time.perf_counter() - start
+        labels = {"path": request.url.path, "method": request.method}
+        try:
+            self.pusher.push_metric("api_request_count", 1, labels)
+            self.pusher.push_metric("api_request_latency_seconds", duration, labels)
+        except (
+            Exception
+        ):  # pragma: no cover - pushing metrics should not break requests
+            logger.exception("Failed to push Prometheus metrics")
+        return response
+
 
 from .utils.logging_config import setup_logging
 
@@ -96,6 +127,8 @@ def create_app(orchestrator: SolutionOrchestrator | None = None) -> FastAPI:
         allow_methods=["*"],
         allow_headers=["*"],
     )
+    if settings.PROMETHEUS_PUSHGATEWAY:
+        app.add_middleware(MetricsMiddleware, job="api")
     workflow_dir = Path(__file__).resolve().parent / "workflows" / "saved"
 
     async def _auth(request: Request, x_api_key: str | None = Header(None)) -> None:

--- a/tests/test_metrics_middleware.py
+++ b/tests/test_metrics_middleware.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+import src.api as api
+from src.solution_orchestrator import SolutionOrchestrator
+
+
+def test_metrics_middleware_enabled(monkeypatch):
+    api.settings.PROMETHEUS_PUSHGATEWAY = "http://example:9091"
+    api.settings.API_AUTH_KEY = None
+
+    with patch("src.api.PrometheusPusher") as MockPusher:
+        instance = MockPusher.return_value
+        app = api.create_app(SolutionOrchestrator({}))
+        client = TestClient(app)
+
+        response = client.get("/activity")
+        assert response.status_code == 200
+
+        labels = {"path": "/activity", "method": "GET"}
+        instance.push_metric.assert_any_call("api_request_count", 1, labels)
+        args, kwargs = instance.push_metric.call_args_list[1]
+        assert args[0] == "api_request_latency_seconds"
+        assert kwargs["labels"] == labels
+
+
+def test_metrics_middleware_disabled(monkeypatch):
+    api.settings.PROMETHEUS_PUSHGATEWAY = None
+
+    app = api.create_app(SolutionOrchestrator({}))
+    client = TestClient(app)
+    response = client.get("/activity")
+    assert response.status_code == 200
+    assert not any(m.cls.__name__ == "MetricsMiddleware" for m in app.user_middleware)


### PR DESCRIPTION
## Summary
- push request metrics to Prometheus when configured
- document metrics collection and environment variable
- expose metrics docs in TOC and README
- test that PrometheusPusher is triggered

## Testing
- `black src/api.py tests/test_metrics_middleware.py`
- `flake8 src/api.py tests/test_metrics_middleware.py` *(fails: command not found)*
- `mypy src/api.py tests/test_metrics_middleware.py` *(fails: found many errors)*
- `pytest -q tests/test_metrics_middleware.py` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6879e7906ab8832ba008e7bf8aece580