### PR TITLE
Add pluggable EventBus with Redis adapter

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -163,9 +163,10 @@ Beyond the standard setup you can extend almost every component:
   endpoints in your favorite database or caching layer and point
   `src.memory_service.MemoryService` to the new base URL.
 * **Pluggable EventBus** – the in-memory bus works for single-process demos. In
-  production you might adapt it to wrap Redis pub/sub or Kafka topics. As long
-  as the API exposes `subscribe(topic, handler)` and `publish(topic, data)` the
-  orchestrators will function the same.
+  production you can switch to `RedisEventBus` or implement adapters for Kafka
+  or RabbitMQ. Set `EVENT_BUS_BACKEND` to `redis` and provide `REDIS_URL` to
+  enable cross-process dispatch. Any backend exposing `subscribe(topic, handler)`
+  and `publish(topic, data)` will integrate seamlessly with the orchestrators.
 * **Custom Providers** – AutoGen agents rely on model providers for LLM access.
   You can create new providers for different AI services by implementing the
   same interface that `OpenAIChatCompletionClient` exposes and referencing that

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -81,6 +81,10 @@ variables documented below.
 - `MEMORY_REDIS_URL` – Redis URL when `MEMORY_BACKEND=redis`.
 - `MEMORY_EMBED_FIELD` – Payload field containing text when `MEMORY_BACKEND=embedding`.
 
+## Event Bus
+- `EVENT_BUS_BACKEND` – Implementation used for pub/sub (`memory` or `redis`).
+- `REDIS_URL` – Connection string for the Redis bus when `EVENT_BUS_BACKEND=redis`.
+
 ## Messaging & Notifications
 - `SENDGRID_API_KEY` – SendGrid API key.
 - `DEFAULT_FROM_EMAIL` – Address used as the sender when none is provided.

--- a/src/base_orchestrator.py
+++ b/src/base_orchestrator.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 from typing import Any, Dict, Type
 import inspect
 
-from agentic_core import EventBus, AsyncEventBus, run_sync, run_maybe_async
+from agentic_core import (
+    EventBus,
+    AsyncEventBus,
+    create_event_bus,
+    run_sync,
+    run_maybe_async,
+)
 from .events import (
     LeadCaptureEvent,
     ChatbotEvent,
@@ -29,7 +35,7 @@ class BaseOrchestrator:
         bus: EventBus | AsyncEventBus | None = None,
         memory: BaseMemoryService | None = None,
     ) -> None:
-        self.bus = bus or AsyncEventBus()
+        self.bus = bus or create_event_bus(async_mode=True)
         self.memory = memory
         self.agents: Dict[str, Any] = {}
         self.event_schemas: Dict[str, Type[Any]] = {

--- a/src/config.py
+++ b/src/config.py
@@ -109,6 +109,7 @@ class Settings(BaseSettings):
     GCS_BUCKET_NAME: Optional[str] = None
     GOOGLE_APPLICATION_CREDENTIALS: Optional[str] = None
     REDIS_URL: Optional[str] = None
+    EVENT_BUS_BACKEND: Literal["memory", "redis"] = "memory"
     DB_CONNECTION_STRING: Optional[str] = None
     KAFKA_BOOTSTRAP_SERVERS: Optional[str] = None
     RABBITMQ_URL: Optional[str] = None

--- a/src/event_bus/__init__.py
+++ b/src/event_bus/__init__.py
@@ -1,0 +1,32 @@
+"""Pluggable event bus implementations."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from .base import BaseEventBus
+from .in_memory import InMemoryEventBus, AsyncInMemoryEventBus
+from .redis import RedisEventBus, AsyncRedisEventBus
+from ..config import settings
+
+__all__ = [
+    "BaseEventBus",
+    "InMemoryEventBus",
+    "AsyncInMemoryEventBus",
+    "RedisEventBus",
+    "AsyncRedisEventBus",
+    "create_event_bus",
+]
+
+
+def create_event_bus(async_mode: bool = True) -> BaseEventBus:
+    """Factory returning an event bus based on configuration."""
+
+    backend = os.getenv("EVENT_BUS_BACKEND", settings.EVENT_BUS_BACKEND)
+    if backend == "redis":
+        url = settings.REDIS_URL or "redis://localhost:6379/0"
+        return AsyncRedisEventBus(url) if async_mode else RedisEventBus(url)
+
+    return AsyncInMemoryEventBus() if async_mode else InMemoryEventBus()
+

--- a/src/event_bus/base.py
+++ b/src/event_bus/base.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+"""Abstract interface and helpers for event bus adapters."""
+
+import abc
+from typing import Any, Callable
+
+
+class BaseEventBus(abc.ABC):
+    """Define the minimal publish/subscribe API used across the project."""
+
+    @abc.abstractmethod
+    def subscribe(self, topic: str, fn: Callable[[dict], Any]) -> None:
+        """Register ``fn`` as a callback for ``topic`` events."""
+
+    @abc.abstractmethod
+    def publish(self, topic: str, payload: dict) -> Any:
+        """Emit ``payload`` to all subscribers of ``topic``."""
+

--- a/src/event_bus/in_memory.py
+++ b/src/event_bus/in_memory.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+"""In-memory event bus implementations."""
+
+import asyncio
+import inspect
+from typing import Any, Callable, Dict, List
+
+from .base import BaseEventBus
+
+
+class InMemoryEventBus(BaseEventBus):
+    """Very small synchronous pub/sub bus."""
+
+    def __init__(self) -> None:
+        self._subs: Dict[str, List[Callable[[dict], Any]]] = {}
+
+    def subscribe(self, topic: str, fn: Callable[[dict], Any]) -> None:
+        self._subs.setdefault(topic, []).append(fn)
+
+    def publish(self, topic: str, payload: dict) -> None:
+        for fn in self._subs.get(topic, []):
+            fn(payload)
+
+
+class AsyncInMemoryEventBus(InMemoryEventBus):
+    """Asynchronous variant of :class:`InMemoryEventBus`."""
+
+    async def publish(self, topic: str, payload: dict) -> None:
+        tasks = []
+        for fn in self._subs.get(topic, []):
+            if inspect.iscoroutinefunction(fn):
+                tasks.append(asyncio.create_task(fn(payload)))
+            else:
+                tasks.append(asyncio.create_task(asyncio.to_thread(fn, payload)))
+        if tasks:
+            await asyncio.gather(*tasks)
+

--- a/src/event_bus/redis.py
+++ b/src/event_bus/redis.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+"""Redis based event bus implementations."""
+
+import asyncio
+import inspect
+import json
+import threading
+import types
+from typing import Any, Callable, Dict, List, Optional
+
+from .base import BaseEventBus
+import logging
+
+try:  # optional dependency
+    import redis  # type: ignore
+except Exception:  # pragma: no cover - fallback when redis is missing
+    redis = types.SimpleNamespace(
+        Redis=types.SimpleNamespace(
+            from_url=lambda *a, **k: types.SimpleNamespace(
+                publish=lambda *a, **k: None,
+                pubsub=lambda *a, **k: types.SimpleNamespace(
+                    subscribe=lambda *a, **k: None,
+                    listen=lambda: iter(()),
+                ),
+                ping=lambda *a, **k: True,
+            )
+        )
+    )
+
+logger = logging.getLogger(__name__)
+
+
+class RedisEventBus(BaseEventBus):
+    """Publish/subscribe using Redis channels."""
+
+    def __init__(self, url: str, *, client: Any | None = None) -> None:
+        self.client = client or redis.Redis.from_url(url, decode_responses=True)
+        self.pubsub = self.client.pubsub(ignore_subscribe_messages=True)
+        self._subs: Dict[str, List[Callable[[dict], Any]]] = {}
+        self._thread = threading.Thread(target=self._listen, daemon=True)
+        self._thread.start()
+        try:  # pragma: no cover - network failure not relevant for unit tests
+            self.client.ping()
+        except Exception as exc:  # pragma: no cover - log only
+            logger.warning(f"Redis ping failed: {exc}")
+
+    def subscribe(self, topic: str, fn: Callable[[dict], Any]) -> None:
+        first = topic not in self._subs
+        self._subs.setdefault(topic, []).append(fn)
+        if first:
+            self.pubsub.subscribe(topic)
+
+    def publish(self, topic: str, payload: dict) -> None:
+        try:
+            self.client.publish(topic, json.dumps(payload))
+        except Exception as exc:  # pragma: no cover - runtime errors
+            logger.error(f"Redis publish failed: {exc}")
+
+    def _handle_message(self, topic: str, payload: dict) -> None:
+        for fn in self._subs.get(topic, []):
+            if inspect.iscoroutinefunction(fn):
+                asyncio.run(fn(payload))
+            else:
+                fn(payload)
+
+    def _listen(self) -> None:
+        for msg in self.pubsub.listen():
+            if msg.get("type") != "message":
+                continue
+            try:
+                data = json.loads(msg["data"])
+            except Exception:
+                continue
+            topic = msg["channel"]
+            self._handle_message(topic, data)
+
+
+class AsyncRedisEventBus(RedisEventBus):
+    """Async wrapper around :class:`RedisEventBus`."""
+
+    def __init__(self, url: str, *, client: Any | None = None, loop: Optional[asyncio.AbstractEventLoop] = None) -> None:
+        self.loop = loop or asyncio.get_event_loop()
+        super().__init__(url, client=client)
+
+    def _handle_message(self, topic: str, payload: dict) -> None:
+        for fn in self._subs.get(topic, []):
+            if inspect.iscoroutinefunction(fn):
+                self.loop.create_task(fn(payload))
+            else:
+                self.loop.create_task(asyncio.to_thread(fn, payload))
+
+    async def publish(self, topic: str, payload: dict) -> None:
+        await asyncio.to_thread(super().publish, topic, payload)
+

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -25,7 +25,13 @@ try:  # pragma: no cover - optional dependency
 except Exception:  # pragma: no cover - optional dependency
     openai = None
 
-from agentic_core import EventBus, AsyncEventBus, run_maybe_async, run_sync
+from agentic_core import (
+    EventBus,
+    AsyncEventBus,
+    create_event_bus,
+    run_maybe_async,
+    run_sync,
+)
 
 from .base_orchestrator import BaseOrchestrator
 
@@ -119,7 +125,7 @@ class Orchestrator(BaseOrchestrator):
             Path used by the ``file`` backend if specified.
         """
 
-        bus = AsyncEventBus()
+        bus = create_event_bus(async_mode=True)
 
         backend = memory_backend or settings.MEMORY_BACKEND
         if backend == "file":

--- a/src/team_orchestrator.py
+++ b/src/team_orchestrator.py
@@ -35,7 +35,7 @@ except Exception:  # pragma: no cover - optional dependency
 
     jsonschema = types.SimpleNamespace(validate=_validate, ValidationError=_VE)
 
-from agentic_core import EventBus, AsyncEventBus
+from agentic_core import EventBus, AsyncEventBus, create_event_bus
 
 try:  # pragma: no cover - PyYAML is optional
     import yaml  # type: ignore
@@ -126,7 +126,7 @@ class TeamOrchestrator(BaseOrchestrator):
                         f"Agent '{name}' not permitted by responsibilities"
                     )
 
-        bus = bus or AsyncEventBus()
+        bus = bus or create_event_bus(async_mode=True)
         super().__init__(bus=bus)
 
         for part in participants:

--- a/tests/httpx_stub.py
+++ b/tests/httpx_stub.py
@@ -26,6 +26,21 @@ class MockTransport:
         return await self.handler(request)
 
 
+class BaseTransport:
+    """Dummy transport base used by FastAPI TestClient."""
+    pass
+
+
+class Client:
+    """Synchronous HTTP client placeholder used by FastAPI TestClient."""
+    def __init__(self, *a, **k):
+        pass
+
+
+class _client:
+    CookieTypes = None
+
+
 class AsyncClient:
     def __init__(self, transport=None, base_url=""):
         self.transport = transport or MockTransport(lambda req: Response())

--- a/tests/test_redis_event_bus.py
+++ b/tests/test_redis_event_bus.py
@@ -1,0 +1,72 @@
+import multiprocessing
+import time
+
+from src.event_bus.redis import redis as redis_module
+from src.event_bus import RedisEventBus
+
+
+class DummyServer:
+    """Cross-process pub/sub store using a shared queue."""
+
+    def __init__(self, manager):
+        self.queue = manager.Queue()
+
+    def publish(self, channel, message):
+        self.queue.put((channel, message))
+
+    def listen(self, channels):
+        while True:
+            channel, message = self.queue.get()
+            if channel in channels:
+                yield {"type": "message", "channel": channel, "data": message}
+
+
+class DummyRedis:
+    def __init__(self, server):
+        self.server = server
+
+    def ping(self):
+        return True
+
+    def publish(self, channel, message):
+        self.server.publish(channel, message)
+
+    def pubsub(self, ignore_subscribe_messages=True):
+        server = self.server
+        class PS:
+            def __init__(self):
+                self.channels = []
+            def subscribe(self, *chs):
+                self.channels.extend(chs)
+            def listen(self):
+                return server.listen(self.channels)
+        return PS()
+
+
+def _publish(url, server):
+    redis_module.Redis.from_url = lambda *a, **k: DummyRedis(server)
+    bus = RedisEventBus(url)
+    bus.publish("demo", {"x": 1})
+    time.sleep(0.2)
+
+
+def test_cross_process_publish(monkeypatch):
+    manager = multiprocessing.Manager()
+    server = DummyServer(manager)
+    monkeypatch.setattr(redis_module.Redis, "from_url", lambda *a, **k: DummyRedis(server))
+
+    bus = RedisEventBus("redis://x")
+    received = []
+    bus.subscribe("demo", lambda p: received.append(p))
+
+    p = multiprocessing.Process(target=_publish, args=("redis://x", server))
+    p.start()
+    p.join(timeout=3)
+    assert p.exitcode == 0
+
+    deadline = time.time() + 2
+    while not received and time.time() < deadline:
+        time.sleep(0.05)
+
+    assert received == [{"x": 1}]
+


### PR DESCRIPTION
## Summary
- introduce event_bus package with memory and Redis implementations
- configure EVENT_BUS_BACKEND and factory helper
- use create_event_bus across orchestrators
- document environment variables and architecture notes
- add cross-process RedisEventBus test and improve httpx stub

## Testing
- `mypy .` *(fails: lots of type errors)*
- `pytest -q` *(fails: missing httpx features)*

------
https://chatgpt.com/codex/tasks/task_e_6879f0f7f7d4832b9b4d2613532e165a