### PR TITLE
Add HVAC, medical and e-commerce workflow templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,60 @@ Available templates:
   # orch.execute_goal("sales_outreach")
   ```
 
+* **hvac_service.json** / **hvac_service.yaml** – schedule, dispatch and invoice
+  an HVAC job.
+
+  ```python
+  with open("workflows/templates/hvac_service.json") as fh:
+      plans = json.load(fh)
+  orch = SolutionOrchestrator({"hvac": "workflows/templates/hvac_team.json"},
+                              planner_plans=plans)
+  orch.execute_goal("hvac_service")
+
+  # YAML
+  # with open("workflows/templates/hvac_service.yaml") as fh:
+  #     plans = yaml.safe_load(fh)
+  # orch = SolutionOrchestrator({"hvac": "workflows/templates/hvac_team.yaml"},
+  #                             planner_plans=plans)
+  # orch.execute_goal("hvac_service")
+  ```
+
+* **medical_practice.json** / **medical_practice.yaml** – manage a patient visit
+  from check-in to billing.
+
+  ```python
+  with open("workflows/templates/medical_practice.json") as fh:
+      plans = json.load(fh)
+  orch = SolutionOrchestrator({"medical": "workflows/templates/medical_practice_team.json"},
+                              planner_plans=plans)
+  orch.execute_goal("medical_practice")
+
+  # YAML
+  # with open("workflows/templates/medical_practice.yaml") as fh:
+  #     plans = yaml.safe_load(fh)
+  # orch = SolutionOrchestrator({"medical": "workflows/templates/medical_practice_team.yaml"},
+  #                             planner_plans=plans)
+  # orch.execute_goal("medical_practice")
+  ```
+
+* **ecommerce_order.json** / **ecommerce_order.yaml** – create, fulfil and
+  notify about an online order.
+
+  ```python
+  with open("workflows/templates/ecommerce_order.json") as fh:
+      plans = json.load(fh)
+  orch = SolutionOrchestrator({"ecommerce": "src/teams/ecommerce_team.json"},
+                              planner_plans=plans)
+  orch.execute_goal("ecommerce_order")
+
+  # YAML
+  # with open("workflows/templates/ecommerce_order.yaml") as fh:
+  #     plans = yaml.safe_load(fh)
+  # orch = SolutionOrchestrator({"ecommerce": "src/teams/ecommerce_team.yaml"},
+  #                             planner_plans=plans)
+  # orch.execute_goal("ecommerce_order")
+  ```
+
 For a branching graph example see
 [docs/workflows.md#branching-logic-and-error-handling](docs/workflows.md#branching-logic-and-error-handling).
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -122,3 +122,20 @@ for entry in result["results"]:
 ``StopIteration`` when no nodes remain. Exceptions from
 ``handle_event_sync`` propagate to the caller so they can be handled
 application‑side.
+
+## Workflow Templates
+
+Example plans live in `workflows/templates` and are provided in both JSON and
+YAML formats. Load a template with `json.load` or `yaml.safe_load` and pass the
+resulting dictionary to `SolutionOrchestrator` via `planner_plans`.
+
+Available templates:
+
+| Template | Description |
+| -------- | ----------- |
+| `blog_post` | Outline, draft and finalise a blog post |
+| `document_summary` | Summarise a document with `AnalystAgent` |
+| `sales_outreach` | Capture a lead and send outreach |
+| `hvac_service` | Schedule, dispatch and invoice an HVAC job |
+| `medical_practice` | Check in a patient and generate billing |
+| `ecommerce_order` | Create an order and notify the customer |

--- a/src/teams/ecommerce_team.yaml
+++ b/src/teams/ecommerce_team.yaml
@@ -1,0 +1,49 @@
+provider: autogen.agentchat.teams.RoundRobinGroupChat
+component_type: team
+version: 1
+component_version: 1
+description: E-commerce order management team.
+label: E-commerce Team
+responsibilities:
+  - ecommerce_agent
+  - fulfillment_agent
+  - notification_agent
+config:
+  participants:
+    - provider: src.agents.roles.AssistantAgent
+      component_type: agent
+      version: 1
+      component_version: 1
+      description: Create ecommerce orders.
+      label: Ecommerce Agent
+      config:
+        name: ecommerce_agent
+    - provider: src.agents.roles.AssistantAgent
+      component_type: agent
+      version: 1
+      component_version: 1
+      description: Fulfill ecommerce orders and update inventory.
+      label: Fulfillment Agent
+      config:
+        name: fulfillment_agent
+    - provider: src.agents.roles.AssistantAgent
+      component_type: agent
+      version: 1
+      component_version: 1
+      description: Send notifications to Microsoft Teams.
+      label: Notification Agent
+      config:
+        name: notification_agent
+  termination_condition:
+    provider: autogen.agentchat.base.OrTerminationCondition
+    component_type: termination
+    label: TerminateOnText
+    config:
+      conditions:
+        - provider: autogen.agentchat.conditions.TextMentionTermination
+          component_type: termination
+          label: TermOnText
+          config:
+            text: TERMINATE
+  emit_team_events: false
+

--- a/tests/test_workflow_templates.py
+++ b/tests/test_workflow_templates.py
@@ -7,6 +7,7 @@ yaml = pytest.importorskip("yaml")
 
 
 from src.solution_orchestrator import SolutionOrchestrator
+from src.team_orchestrator import TeamOrchestrator
 
 TEMPLATE_DIR = Path("workflows/templates")
 
@@ -27,14 +28,59 @@ def test_blog_post_workflow(tmp_path):
 
 
 def test_template_files_parse():
-    for base in ["writer_team", "analysis_team"]:
+    for base in [
+        "writer_team",
+        "analysis_team",
+        "hvac_team",
+        "medical_practice_team",
+    ]:
         for ext in ("json", "yaml"):
             data = (TEMPLATE_DIR / f"{base}.{ext}").read_text()
             parsed = json.loads(data) if ext == "json" else yaml.safe_load(data)
             assert "config" in parsed
 
-    for base in ["blog_post", "document_summary", "sales_outreach"]:
+    for base in [
+        "blog_post",
+        "document_summary",
+        "sales_outreach",
+        "hvac_service",
+        "medical_practice",
+        "ecommerce_order",
+    ]:
         for ext in ("json", "yaml"):
             data = (TEMPLATE_DIR / f"{base}.{ext}").read_text()
             parsed = json.loads(data) if ext == "json" else yaml.safe_load(data)
             assert isinstance(parsed, dict)
+
+
+def test_template_teams_load_via_team_orchestrator():
+    files = [
+        TEMPLATE_DIR / "hvac_team.json",
+        TEMPLATE_DIR / "hvac_team.yaml",
+        TEMPLATE_DIR / "medical_practice_team.json",
+        TEMPLATE_DIR / "medical_practice_team.yaml",
+        Path("src/teams/ecommerce_team.json"),
+        Path("src/teams/ecommerce_team.yaml"),
+    ]
+    for path in files:
+        orch = TeamOrchestrator(str(path))
+        assert orch.team_config["config"]["participants"]
+
+
+def test_hvac_and_medical_workflows(tmp_path):
+    cases = [
+        ("hvac", "hvac_service"),
+        ("medical", "medical_practice"),
+    ]
+    for name, workflow in cases:
+        for ext in ("json", "yaml"):
+            team_file = TEMPLATE_DIR / f"{name}_team.{ext}"
+            plan_file = TEMPLATE_DIR / f"{workflow}.{ext}"
+            if ext == "json":
+                plans = json.loads(plan_file.read_text())
+            else:
+                plans = yaml.safe_load(plan_file.read_text())
+
+            orch = SolutionOrchestrator({name: str(team_file)}, planner_plans=plans)
+            result = orch.execute_goal(workflow)
+            assert result["status"] == "complete"

--- a/workflows/templates/ecommerce_order.json
+++ b/workflows/templates/ecommerce_order.json
@@ -1,0 +1,16 @@
+{
+  "ecommerce_order": [
+    {
+      "team": "ecommerce",
+      "event": {"type": "ecommerce_agent", "payload": {"order": {"item": "Widget", "qty": 1}}}
+    },
+    {
+      "team": "ecommerce",
+      "event": {"type": "fulfillment_agent", "payload": {}}
+    },
+    {
+      "team": "ecommerce",
+      "event": {"type": "notification_agent", "payload": {"message": "Order shipped"}}
+    }
+  ]
+}

--- a/workflows/templates/ecommerce_order.yaml
+++ b/workflows/templates/ecommerce_order.yaml
@@ -1,0 +1,17 @@
+ecommerce_order:
+  - team: ecommerce
+    event:
+      type: ecommerce_agent
+      payload:
+        order:
+          item: Widget
+          qty: 1
+  - team: ecommerce
+    event:
+      type: fulfillment_agent
+      payload: {}
+  - team: ecommerce
+    event:
+      type: notification_agent
+      payload:
+        message: Order shipped

--- a/workflows/templates/hvac_service.json
+++ b/workflows/templates/hvac_service.json
@@ -1,0 +1,16 @@
+{
+  "hvac_service": [
+    {
+      "team": "hvac",
+      "event": {"type": "hvac_agent", "payload": {"action": "schedule_service", "customer": "ACME Industries"}}
+    },
+    {
+      "team": "hvac",
+      "event": {"type": "hvac_agent", "payload": {"action": "dispatch"}}
+    },
+    {
+      "team": "hvac",
+      "event": {"type": "hvac_agent", "payload": {"action": "invoice"}}
+    }
+  ]
+}

--- a/workflows/templates/hvac_service.yaml
+++ b/workflows/templates/hvac_service.yaml
@@ -1,0 +1,17 @@
+hvac_service:
+  - team: hvac
+    event:
+      type: hvac_agent
+      payload:
+        action: schedule_service
+        customer: ACME Industries
+  - team: hvac
+    event:
+      type: hvac_agent
+      payload:
+        action: dispatch
+  - team: hvac
+    event:
+      type: hvac_agent
+      payload:
+        action: invoice

--- a/workflows/templates/hvac_team.json
+++ b/workflows/templates/hvac_team.json
@@ -1,0 +1,11 @@
+{
+  "responsibilities": ["hvac_agent"],
+  "config": {
+    "participants": [
+      {
+        "provider": "src.agents.roles.AssistantAgent",
+        "config": {"name": "hvac_agent"}
+      }
+    ]
+  }
+}

--- a/workflows/templates/hvac_team.yaml
+++ b/workflows/templates/hvac_team.yaml
@@ -1,0 +1,7 @@
+responsibilities:
+  - hvac_agent
+config:
+  participants:
+    - provider: src.agents.roles.AssistantAgent
+      config:
+        name: hvac_agent

--- a/workflows/templates/medical_practice.json
+++ b/workflows/templates/medical_practice.json
@@ -1,0 +1,16 @@
+{
+  "medical_practice": [
+    {
+      "team": "medical",
+      "event": {"type": "medical_agent", "payload": {"action": "check_in", "patient": "Jane Doe"}}
+    },
+    {
+      "team": "medical",
+      "event": {"type": "medical_agent", "payload": {"action": "update_records"}}
+    },
+    {
+      "team": "medical",
+      "event": {"type": "medical_agent", "payload": {"action": "generate_invoice"}}
+    }
+  ]
+}

--- a/workflows/templates/medical_practice.yaml
+++ b/workflows/templates/medical_practice.yaml
@@ -1,0 +1,17 @@
+medical_practice:
+  - team: medical
+    event:
+      type: medical_agent
+      payload:
+        action: check_in
+        patient: Jane Doe
+  - team: medical
+    event:
+      type: medical_agent
+      payload:
+        action: update_records
+  - team: medical
+    event:
+      type: medical_agent
+      payload:
+        action: generate_invoice

--- a/workflows/templates/medical_practice_team.json
+++ b/workflows/templates/medical_practice_team.json
@@ -1,0 +1,11 @@
+{
+  "responsibilities": ["medical_agent"],
+  "config": {
+    "participants": [
+      {
+        "provider": "src.agents.roles.AssistantAgent",
+        "config": {"name": "medical_agent"}
+      }
+    ]
+  }
+}

--- a/workflows/templates/medical_practice_team.yaml
+++ b/workflows/templates/medical_practice_team.yaml
@@ -1,0 +1,7 @@
+responsibilities:
+  - medical_agent
+config:
+  participants:
+    - provider: src.agents.roles.AssistantAgent
+      config:
+        name: medical_agent


### PR DESCRIPTION
## Summary
- add hvac, medical practice and ecommerce workflow templates
- provide minimal team definitions for hvac and medical practice
- supply YAML version of ecommerce team
- document templates in README and docs site
- extend tests to load new templates via TeamOrchestrator

## Testing
- `pytest tests/test_workflow_templates.py -k test_template_files_parse -q` *(fails: 1 skipped)*
- `pytest tests/test_workflow_templates.py -k test_template_files_parse -q` *(fails: 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6879f13a6a30832ba7a32ed056474172