### PR TITLE
Build docs on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,3 +58,27 @@ jobs:
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
           platforms: linux/amd64,linux/arm64
+
+  docs:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+      - name: Build documentation
+        run: make -C docs html
+      - name: Disable Jekyll
+        run: touch docs/_build/html/.nojekyll
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/_build/html
+          publish_branch: gh-pages

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 Welcome to the Brookside BI Agentic System! This repo contains a modular, turn-based framework of specialized AI “expert” agents that power everything from lead capture to contract delivery, all orchestrated under a central Orchestrator agent. Whether you’re adding a new campaign agent or tweaking your CRM integration, you’ll find a clean separation of concerns that makes extending and testing your workflow a breeze. A lightweight `crm_connector` module now fetches deals directly from your CRM using `CRM_API_URL` and `CRM_API_KEY`.
 
+Full documentation is available at [https://brooksidebi.github.io/portfolio/](https://brooksidebi.github.io/portfolio/).
+
 For a deeper explanation of the architecture—including the event bus, memory service and how AutoGen teams are loaded and how teams start running—see [docs/architecture.md](docs/architecture.md).
 
 ## ⚡ Quick Start

--- a/docs/api_examples.md
+++ b/docs/api_examples.md
@@ -1,0 +1,49 @@
+# API Examples
+
+This page demonstrates common interactions with the `SolutionOrchestrator` HTTP interface and its Python API. Copy the commands below to quickly integrate the orchestrator into your own tooling or scripts.
+
+## Running the API server
+
+Launch the FastAPI server that exposes your teams:
+
+```bash
+python -m src.api --sales=src/teams/sales_team_full.json
+```
+
+The server listens on port `8000` by default. Set the `PORT` environment variable to change it.
+
+## Sending an event via `curl`
+
+```bash
+curl -X POST \
+     -H 'Content-Type: application/json' \
+     -d '{"type": "lead_capture", "payload": {"email": "alice@example.com"}}' \
+     http://localhost:8000/teams/sales/event
+```
+
+The response contains the orchestrator result as JSON.
+
+## Streaming team status
+
+```bash
+curl http://localhost:8000/teams/sales/stream
+```
+
+This command prints a Server-Sent Events stream of status updates and activity messages.
+
+## Python usage
+
+```python
+from src.solution_orchestrator import SolutionOrchestrator
+
+async def main() -> None:
+    async with SolutionOrchestrator({"sales": "src/teams/sales_team_full.json"}) as orch:
+        result = await orch.handle_event(
+            "sales",
+            {"type": "lead_capture", "payload": {"email": "alice@example.com"}},
+        )
+        print(result)
+```
+
+Executing `main()` dispatches an event to the `sales` team and prints the structured result.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,5 +14,6 @@ Welcome to the Brookside BI documentation. Here you'll find guides and reference
 - [Component Guide](components.md) – Dive into the modules and orchestrators.
 - [Environment Variable Reference](environment.md) – Configure your runtime environment.
 - [Command Line Reference](cli.md) – Manage the orchestrator via `brookside-cli`.
+- [API Examples](api_examples.md) – Interact with the HTTP server or Python API.
 
 For more topics, browse the other documents in this folder.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,4 +15,6 @@ Welcome to the documentation for the Brookside BI agentic system.
    metrics
    agents_overview
    workflows
+   cli
+   api_examples
 


### PR DESCRIPTION
## Summary
- build docs on release and publish to `gh-pages`
- add public docs link to README
- link CLI and API docs in index
- provide API usage examples

## Testing
- `pytest -q` *(fails: AttributeError: module 'tests.httpx_stub' has no attribute 'BaseTransport')*

------
https://chatgpt.com/codex/tasks/task_e_6879f13cc0a4832b98ff96e967229d6e