### PR TITLE
Add pinned Docker base, multi-arch CI and Helm chart

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -5,16 +5,35 @@ on:
   push:
     branches: [main]
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
-  build:
+  docker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Build image
+      - name: Log in to registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build and optionally push
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: false
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name == 'push' }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,5 +56,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
           platforms: linux/amd64,linux/arm64
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.11-slim
+# Pinned digest for python:3.11-slim to ensure reproducible builds
+FROM python@sha256:0df0b6c8ee6285ef3a0655e768f8b51006979cd13e341fa9a316bed36b1cfc7d
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -511,6 +511,23 @@ The compose file starts two services:
 The orchestrator is automatically configured to talk to the memory service at
 `http://memory:8000`.
 
+Prebuilt images are published for every release.  Pull the latest version from
+GitHub Container Registry:
+
+```bash
+docker pull ghcr.io/brooksidebi/portfolio:<tag>
+```
+
+Replace `<tag>` with a version from the [releases page](https://github.com/BrooksideBI/portfolio/releases).
+
+The repository also provides a lightweight Helm chart under `helm/` which uses
+these images for Kubernetes deployments:
+
+```bash
+helm install brookside ./helm/brookside --set image.tag=<tag>
+```
+See [docs/helm.md](docs/helm.md) for additional configuration options.
+
 To use Redis instead of the bundled FastAPI memory server, start a Redis
 container and point the orchestrator at it:
 
@@ -699,8 +716,9 @@ Releases are automated through GitHub Actions. Pushing a tag matching
 
 1. Builds the Python package using `python -m build`.
 2. Creates multi-architecture Docker images (`linux/amd64` and `linux/arm64`).
-3. Publishes the images to Docker Hub or GHCR using credentials from repository
-   secrets (`DOCKER_USERNAME` and `DOCKER_PASSWORD`).
+3. Publishes the images to GitHub Container Registry using credentials from
+   repository secrets (`DOCKER_USERNAME` and `DOCKER_PASSWORD`). Images are
+   tagged with the release version and `latest`.
 4. Uploads the wheel and source distribution files as assets on the GitHub
    release.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -30,3 +30,10 @@ pytest -q
 ```
 
 Only publish the tag once all tests pass.
+
+After the workflow publishes the release you can pull the container image using
+the same version tag:
+
+```bash
+docker pull ghcr.io/brooksidebi/portfolio:vX.Y.Z
+```

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -1,0 +1,13 @@
+# Helm Deployment
+
+A lightweight Helm chart is provided under `helm/` to simplify Kubernetes deployments.
+
+Install the chart from the repository root:
+
+```bash
+helm install brookside ./helm/brookside \
+  --set image.tag=<version>
+```
+
+Set `image.tag` to a version published on GitHub Container Registry. The chart
+deploys a single orchestrator pod exposing port `8000`.

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,0 +1,12 @@
+# Helm Chart
+
+This directory contains a lightweight Helm chart for deploying the Brookside BI orchestrator.
+
+To install the chart locally:
+
+```bash
+helm install brookside ./helm/brookside \
+  --set image.tag=<release>
+```
+
+Replace `<release>` with the desired image tag, e.g. `v1.0.0`.

--- a/helm/brookside/Chart.yaml
+++ b/helm/brookside/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: brookside
+version: 0.1.0
+appVersion: "1.0.0"
+description: Lightweight chart for the Brookside BI orchestrator

--- a/helm/brookside/templates/_helpers.tpl
+++ b/helm/brookside/templates/_helpers.tpl
@@ -1,0 +1,17 @@
+{{- define "brookside.name" -}}
+{{ .Chart.Name }}
+{{- end -}}
+
+{{- define "brookside.fullname" -}}
+{{ include "brookside.name" . }}
+{{- end -}}
+
+{{- define "brookside.labels" -}}
+app.kubernetes.io/name: {{ include "brookside.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "brookside.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "brookside.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/helm/brookside/templates/deployment.yaml
+++ b/helm/brookside/templates/deployment.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "brookside.fullname" . }}
+  labels:
+    {{- include "brookside.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "brookside.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "brookside.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: orchestrator
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args: ["start", "sales=src/teams/sales_team_full.json"]
+          ports:
+            - containerPort: 8000

--- a/helm/brookside/templates/service.yaml
+++ b/helm/brookside/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "brookside.fullname" . }}
+  labels:
+    {{- include "brookside.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 8000
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "brookside.selectorLabels" . | nindent 4 }}

--- a/helm/brookside/values.yaml
+++ b/helm/brookside/values.yaml
@@ -1,0 +1,7 @@
+image:
+  repository: ghcr.io/brooksidebi/portfolio
+  tag: latest
+  pullPolicy: IfNotPresent
+service:
+  type: ClusterIP
+  port: 8000

--- a/tests/test_helm_chart.py
+++ b/tests/test_helm_chart.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+import yaml
+
+
+def test_chart_yaml_loads() -> None:
+    chart = Path('helm/brookside/Chart.yaml')
+    data = yaml.safe_load(chart.read_text())
+    assert data["apiVersion"] == "v2"
+    assert "version" in data
+
+
+def test_values_yaml_loads() -> None:
+    values = Path('helm/brookside/values.yaml')
+    data = yaml.safe_load(values.read_text())
+    assert "image" in data
+    assert "repository" in data["image"]


### PR DESCRIPTION
## Summary
- pin python base image using digest
- push multi-architecture images in Docker workflows
- document Docker images and Helm deployment
- add lightweight Helm chart
- provide test coverage for the chart

## Testing
- `pytest -q tests/test_helm_chart.py` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6879f139d798832bafb70b0bd8ec2099