### PR TITLE
Add model tier policy for orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,22 @@ orch.handle_event("sales", {"type": "lead_capture", "payload": {}})
 
 Teams can report progress upward via `orch.report_status(team, status)`.
 
+### Configurable Model Tiers
+
+`TeamOrchestrator` can replace model names using a policy file. By default
+`configs/model_policy.json` maps **cheap**, **balanced** and **premium** tiers to
+specific models. Any team JSON may reference a tier instead of an explicit model
+name:
+
+```json
+{"config": {"model_client": {"config": {"model": "$tier.premium"}}}}
+```
+
+At load time the orchestrator looks up `premium` in the policy and substitutes
+the actual model name. Adjusting one policy file lets you switch all teams
+between models without editing each JSON individually. Pass a custom path via
+`TeamOrchestrator(policy_path=...)` if needed.
+
 Agents may also advertise a list of `skills`. The orchestrator can route a task
 to the first agent declaring the requested skill:
 

--- a/configs/model_policy.json
+++ b/configs/model_policy.json
@@ -1,0 +1,1 @@
+{"cheap": "gpt-3.5-turbo", "balanced": "gpt-4o-mini", "premium": "gpt-4o"}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -125,6 +125,12 @@ this list and raises an error otherwise.
 
 OpenAI powered components (via `OpenAIChatCompletionClient`) are created using API keys provided by `src.config.settings`.  The settings object reads values from environment variables and the relevant `.env` file.  Whenever an AutoGen agent needs a model response, the provider invokes the OpenAI API to generate the next message.
 
+Model selection can be centralised through `configs/model_policy.json`. Team files
+may specify `"model": "$tier.cheap"` and `TeamOrchestrator` will substitute the
+corresponding model name according to that policy. This allows administrators to
+upgrade or downgrade model quality across all teams by editing a single JSON
+file.
+
 ### AutoGen Invocation
 
 When `TeamOrchestrator.handle_event` receives an event it forwards the payload to the corresponding AutoGen agent. The agent's `model_client` (such as `OpenAIChatCompletionClient`) sends the message to the LLM and returns the response. AutoGen then orchestrates the conversation flow defined in the team configuration, cycling through the participants until a termination condition is met.

--- a/docs/components.md
+++ b/docs/components.md
@@ -89,6 +89,15 @@ Once installed, ``load_plugin('email')`` will return ``EmailPlugin``. Plugins
 placed directly in ``src/plugins/`` do not require registration and are
 automatically importable by name.
 
+### Model Tiers
+
+``TeamOrchestrator`` supports model tier references so teams can switch LLMs
+without editing each JSON file. The default policy is ``configs/model_policy.json``
+mapping ``cheap``, ``balanced`` and ``premium`` to specific model names. Within
+a team configuration you may write ``"model": "$tier.balanced"``. When the team
+is loaded the orchestrator replaces the placeholder with the configured model
+name. Pass ``policy_path`` to ``TeamOrchestrator`` to override the policy file.
+
 You can also resolve components manually using the helper in
 ``src.utils.plugin_loader``:
 

--- a/tests/test_model_policy.py
+++ b/tests/test_model_policy.py
@@ -1,0 +1,62 @@
+import json
+import types
+import sys
+from pathlib import Path
+
+import pytest
+
+from src.team_orchestrator import TeamOrchestrator
+from src.agents.base_agent import BaseAgent
+
+
+class DummyAgent(BaseAgent):
+    def run(self, payload):
+        return payload
+
+
+def _write_team(tmp_path: Path, model_ref: str) -> Path:
+    cfg = {
+        "provider": "autogen.agentchat.teams.RoundRobinGroupChat",
+        "config": {
+            "participants": [
+                {
+                    "config": {
+                        "name": "dummy_agent",
+                        "model_client": {"config": {"model": model_ref}},
+                    }
+                }
+            ]
+        },
+    }
+    path = tmp_path / "team.json"
+    path.write_text(json.dumps(cfg))
+    return path
+
+
+def test_model_policy_resolution(tmp_path: Path):
+    team_cfg = _write_team(tmp_path, "$tier.premium")
+    policy_path = tmp_path / "policy.json"
+    policy_path.write_text(json.dumps({"cheap": "a", "balanced": "b", "premium": "c"}))
+
+    mod = types.ModuleType("src.agents.dummy_agent")
+    mod.DummyAgent = DummyAgent
+    sys.modules["src.agents.dummy_agent"] = mod
+
+    orch = TeamOrchestrator(str(team_cfg), policy_path=str(policy_path))
+    model = orch.team_config["config"]["participants"][0]["config"]["model_client"][
+        "config"
+    ]["model"]
+    assert model == "c"
+
+
+def test_unknown_model_tier(tmp_path: Path):
+    team_cfg = _write_team(tmp_path, "$tier.ultra")
+    policy_path = tmp_path / "policy.json"
+    policy_path.write_text(json.dumps({"cheap": "a"}))
+
+    mod = types.ModuleType("src.agents.dummy_agent")
+    mod.DummyAgent = DummyAgent
+    sys.modules["src.agents.dummy_agent"] = mod
+
+    with pytest.raises(ValueError):
+        TeamOrchestrator(str(team_cfg), policy_path=str(policy_path))


### PR DESCRIPTION
## Summary
- configure default model tiers via `configs/model_policy.json`
- apply policy when loading team files in `TeamOrchestrator`
- document model policy usage in README and docs
- test model tier resolution

## Testing
- `flake8` *(fails: command not found)*
- `mypy .` *(fails: Found 357 errors)*
- `pytest -q` *(fails: module 'tests.httpx_stub' has no attribute 'BaseTransport')*

------
https://chatgpt.com/codex/tasks/task_e_6879f0f6c654832bafbfb2bc151ed364