### PR TITLE
feat: add indexing to event_history

### DIFF
--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,5 +1,6 @@
 from src import db
 from src.config import settings
+import sqlite3
 
 
 def test_db_write_and_read(tmp_path):
@@ -18,3 +19,15 @@ def test_db_write_and_read(tmp_path):
     rows = db.fetch_history(event_type="y")
     assert len(rows) == 1
     assert rows[0]["team"] == "other"
+
+
+def test_db_index_creation(tmp_path):
+    """Ensure indexes for efficient lookups exist after initialisation."""
+    settings.DB_CONNECTION_STRING = f"sqlite:///{tmp_path}/t.db"
+    db.init_db()
+
+    with sqlite3.connect(tmp_path / "t.db") as conn:
+        indexes = [row[1] for row in conn.execute("PRAGMA index_list('event_history')")]
+
+    assert "idx_event_history_timestamp" in indexes
+    assert "idx_event_history_team" in indexes


### PR DESCRIPTION
## Summary
- add creation of timestamp/team indexes in `init_db`
- include migration that checks existing indexes
- test new indexes using `PRAGMA index_list`

## Testing
- `pytest tests/test_db.py::test_db_write_and_read -q`
- `pytest tests/test_db.py::test_db_index_creation -q`
- `pytest -q`
- ❌ `./scripts/setup.sh` *(fails: Tunnel connection failed: 403 Forbidden)*
- ❌ `./scripts/run_tests.sh` *(fails: flake8: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a64008a40832ba5bc0b018677739b