### PR TITLE
Add AsyncBaseMemoryService and integrate with orchestrator

### DIFF
--- a/docs/memory_service.md
+++ b/docs/memory_service.md
@@ -1,8 +1,9 @@
 # Memory Service
 
 The `MemoryService` component persists events so that agents can recall prior
-context. Implementations live under `src/memory_service/` and share a common
-`BaseMemoryService` interface.  The default backend is a thin REST client in
+context. Implementations live under `src/memory_service/` and share either the
+`BaseMemoryService` synchronous interface or the `AsyncBaseMemoryService`
+asynchronous variant. The default backend is a thin REST client in
 `src/memory_service/rest.py` expecting a server exposing `/store` and `/fetch`
 endpoints.
 
@@ -97,4 +98,6 @@ Select the backend using the ``MEMORY_BACKEND`` environment variable (``rest``,
 so they can be placed in a ``.env`` file or exported in your shell.
 
 You can also provide your own implementation by subclassing
-``BaseMemoryService`` and passing an instance to the orchestrator.
+``BaseMemoryService`` for synchronous backends or
+``AsyncBaseMemoryService`` when the operations should be awaited and run
+non-blocking. Instances of either class can be passed to the orchestrator.

--- a/src/memory_service/__init__.py
+++ b/src/memory_service/__init__.py
@@ -1,6 +1,7 @@
 """Memory service backends providing persistent storage for events."""
 
 from .base import BaseMemoryService
+from .async_base import AsyncBaseMemoryService
 from .rest import RestMemoryService
 
 try:  # optional dependency
@@ -13,6 +14,7 @@ from .embedding import EmbeddingMemoryService
 
 __all__ = [
     "BaseMemoryService",
+    "AsyncBaseMemoryService",
     "RestMemoryService",
     "AsyncRestMemoryService",
     "FileMemoryService",

--- a/src/memory_service/async_base.py
+++ b/src/memory_service/async_base.py
@@ -1,0 +1,25 @@
+"""Asynchronous memory service interface."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List
+
+
+class AsyncBaseMemoryService(ABC):
+    """Define an asynchronous storage API used by orchestrators and agents."""
+
+    @abstractmethod
+    async def store(self, key: str, payload: Dict[str, Any]) -> bool:
+        """Persist ``payload`` under ``key`` asynchronously."""
+
+    @abstractmethod
+    async def fetch(self, key: str, top_k: int = 5) -> List[Dict[str, Any]]:
+        """Return up to ``top_k`` records associated with ``key`` asynchronously."""
+
+    async def aclose(self) -> None:  # pragma: no cover - optional hook
+        """Release any underlying resources."""
+        return None
+
+
+__all__ = ["AsyncBaseMemoryService"]

--- a/src/memory_service/rest_async.py
+++ b/src/memory_service/rest_async.py
@@ -21,13 +21,13 @@ except Exception:  # pragma: no cover - test environment fallback
         MockTransport=None,
     )
 
-from .base import BaseMemoryService
+from .async_base import AsyncBaseMemoryService
 import logging
 
 logger = logging.getLogger(__name__)
 
 
-class AsyncRestMemoryService(BaseMemoryService):
+class AsyncRestMemoryService(AsyncBaseMemoryService):
     """Persist events by calling a REST API asynchronously via ``httpx``."""
 
     def __init__(

--- a/tests/test_async_memory_interface.py
+++ b/tests/test_async_memory_interface.py
@@ -1,0 +1,40 @@
+import asyncio
+
+from src.base_orchestrator import BaseOrchestrator
+from src.memory_service.async_base import AsyncBaseMemoryService
+
+
+class DummyAsyncMemory(AsyncBaseMemoryService):
+    """Minimal async memory service used to test orchestrator integration."""
+
+    def __init__(self):
+        self.stored = False
+        self.closed = False
+
+    async def store(self, key: str, payload: dict) -> bool:
+        await asyncio.sleep(0)  # ensure coroutine execution
+        self.stored = True
+        return True
+
+    async def fetch(self, key: str, top_k: int = 5):  # pragma: no cover - unused
+        return []
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+def test_async_memory_usage() -> None:
+    mem = DummyAsyncMemory()
+    orch = BaseOrchestrator(memory=mem)
+
+    res = orch.handle_event_sync({"type": "missing", "payload": {}})
+    # event type is unknown but store should have been awaited
+    assert res["status"] == "ignored"
+    assert mem.stored is True
+
+    async def _run():
+        async with orch:
+            pass
+
+    asyncio.run(_run())
+    assert mem.closed is True


### PR DESCRIPTION
## Summary
- introduce `AsyncBaseMemoryService` for async memory backends
- make `AsyncRestMemoryService` inherit from the new interface
- update orchestrator to await async memory methods and support async cleanup
- extend docs with async interface information
- add tests covering async integration

## Testing
- `./scripts/setup.sh` *(fails: Tunnel connection failed: 403 Forbidden)*
- `./scripts/run_tests.sh` *(fails: flake8 not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a6401a3c4832b9baca033896b535e